### PR TITLE
Fix centralized package management build breaks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,45 +5,45 @@
 
   <ItemGroup Label="Application Packages">
     <!-- Azure and Cloud Services -->
-    <PackageReference Update="Azure.Identity" Version="1.17.1" />
-    <PackageReference Update="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
 
     <!-- ASP.NET Core and Web Components -->
-    <PackageReference Update="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
-    <PackageReference Update="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.22" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.14" />
 
     <!-- Microsoft Extensions -->
-    <PackageReference Update="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
 
     <!-- OpenTelemetry -->
-    <PackageReference Update="OpenTelemetry.Exporter.Console" Version="1.8.1" />
-    <PackageReference Update="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
-    <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
 
     <!-- Third-party Libraries -->
-    <PackageReference Update="I8Beef.TiVo" Version="1.0.0.14" />
-    <PackageReference Update="Microsoft.Playwright" Version="1.48.0" />
-    <PackageReference Update="StreamJsonRpc" Version="2.19.27" />
-    <PackageReference Update="System.Speech" Version="8.0.0" />
-    <PackageReference Update="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="I8Beef.TiVo" Version="1.0.0.14" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.48.0" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.19.27" />
+    <PackageVersion Include="System.Speech" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
 
     <!-- Development Tools -->
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
 
     <!-- Code Analysis -->
-    <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.100" />
   </ItemGroup>
 
   <ItemGroup Label="Test-Only Packages">
     <!-- Test Frameworks -->
-    <PackageReference Update="MSTest" Version="4.0.1" />
-    <PackageReference Update="MSTest.TestAdapter" Version="4.0.1" />
-    <PackageReference Update="MSTest.TestFramework" Version="4.0.1" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="MSTest" Version="3.1.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 
     <!-- Test Utilities -->
-    <PackageReference Update="coverlet.collector" Version="6.0.4" />
-    <PackageReference Update="FluentAssertions" Version="8.8.0" />
-    <PackageReference Update="Moq" Version="4.20.70" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
+    <PackageVersion Include="Moq" Version="4.20.70" />
   </ItemGroup>
 </Project>

--- a/test/AdaptiveRemote.EndtoEndTests/HostTestBase.cs
+++ b/test/AdaptiveRemote.EndtoEndTests/HostTestBase.cs
@@ -54,7 +54,7 @@ public abstract class HostTestBase
             Assert.Inconclusive($"Working directory not found: {hostSettings.WorkingDirectory}");
         }
 
-        string logFilePath = Path.Combine(testContext.TestResultsDirectory!, testContext.TestDisplayName + ".log");
+        string logFilePath = Path.Combine(testContext.TestResultsDirectory!, testContext.TestName + ".log");
 
         hostSettings = hostSettings.AddCommandLineArgs($"--tivo:Fake=True --broadlink:Fake=True --log:FilePath=\"{logFilePath}\"");
 


### PR DESCRIPTION
I shouldn't have trusted Copilot with a simple change. There were version mismatches it mishandled.