### PR TITLE
Another attempt to fix timing-based E2E test failures

### DIFF
--- a/src/AdaptiveRemote/MainWindow.xaml.cs
+++ b/src/AdaptiveRemote/MainWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.ComponentModel;
+using System.Windows;
 
 namespace AdaptiveRemote;
 
@@ -19,5 +20,11 @@ public partial class MainWindow : Window
         base.OnSourceInitialized(e);
 
         Browser.WebView.DefaultBackgroundColor = System.Drawing.Color.FromArgb(0x00, 0x22, 0x22, 0x22);
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        base.OnClosing(e);
+        Browser.WebView.Dispose();
     }
 }

--- a/test/AdaptiveRemote.EndtoEndTests.TestServices/Host/AdaptiveRemoteHost.Builder.cs
+++ b/test/AdaptiveRemote.EndtoEndTests.TestServices/Host/AdaptiveRemoteHost.Builder.cs
@@ -44,6 +44,9 @@ public partial class AdaptiveRemoteHost
 
         public AdaptiveRemoteHost Start(Func<AdaptiveRemoteHostSettings, AdaptiveRemoteHostSettings>? overrideSettings = null)
         {
+            // Add a small random delay to reduce the chance of resource conflicts when starting multiple hosts in parallel
+            Thread.Sleep(Random.Shared.Next(100, 500)); 
+
             AdaptiveRemoteHostSettings effectiveSettings = overrideSettings?.Invoke(_settings) ?? _settings;
             return StartWithSettings(effectiveSettings);
         }


### PR DESCRIPTION
Add a random delay when starting the host, and explicitly clean up WebView2 resources, to try to resolve occasional timing related startup issues with parallel runs of the application.