### PR TITLE
Enable CI builds on pull requests to `feature/` branches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - 'feature/*'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This will allow me to run PR builds on the branches that Copilot or Claude create, so that I don't have to commit them before I know whether the tests really pass.