### PR TITLE
[ADR-177] Mapping from CompiledLayout DTO to internal view models

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.201",
+    "version": "10.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/src/AdaptiveRemote.App/Configuration/CloudAssetServiceExtensions.cs
+++ b/src/AdaptiveRemote.App/Configuration/CloudAssetServiceExtensions.cs
@@ -12,4 +12,9 @@ internal static class CloudAssetServiceExtensions
             .AddSingleton<CloudAssetOrchestrator>()
             .AddSingleton<IPreScopeInitializer>(sp => sp.GetRequiredService<CloudAssetOrchestrator>())
             .AddHostedService(sp => sp.GetRequiredService<CloudAssetOrchestrator>());
+
+    internal static IServiceCollection AddScopedCloudAsset<T>(
+        this IServiceCollection services, string name)
+        where T : class
+        => services.AddScoped(sp => sp.GetRequiredService<ICloudAssetStore>().Get<T>(name));
 }

--- a/src/AdaptiveRemote.App/Configuration/HostBuilderExtensions.cs
+++ b/src/AdaptiveRemote.App/Configuration/HostBuilderExtensions.cs
@@ -29,7 +29,7 @@ internal static class HostBuilderExtensions
         => services
             .AddApplicationLifecycleServices()
             .AddCloudAssetServices()
-            .AddScoped(sp => sp.GetRequiredService<ICloudAssetStore>().Get<CompiledLayout>("layout"))
+            .AddScopedCloudAsset<CompiledLayout>("layout")
             .AddScopedLifecycleService<LifecycleCommandService>()
             .AddScoped<IRemoteDefinitionService, RemoteLayoutDefinitionService>()
             .AddScoped<IDynamicStylesheetProvider, LayoutStylesheetProvider>()

--- a/src/AdaptiveRemote.App/Configuration/HostBuilderExtensions.cs
+++ b/src/AdaptiveRemote.App/Configuration/HostBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using AdaptiveRemote.Services;
+﻿using AdaptiveRemote.Contracts;
+using AdaptiveRemote.Services;
 using AdaptiveRemote.Services.CloudAssets;
 using AdaptiveRemote.Services.Commands;
 using AdaptiveRemote.Services.Layout;
@@ -28,6 +29,7 @@ internal static class HostBuilderExtensions
         => services
             .AddApplicationLifecycleServices()
             .AddCloudAssetServices()
+            .AddScoped(sp => sp.GetRequiredService<ICloudAssetStore>().Get<CompiledLayout>("layout"))
             .AddScopedLifecycleService<LifecycleCommandService>()
             .AddScoped<IRemoteDefinitionService, RemoteLayoutDefinitionService>()
             .AddScoped<IDynamicStylesheetProvider, LayoutStylesheetProvider>()

--- a/src/AdaptiveRemote.App/Models/IRCommand.cs
+++ b/src/AdaptiveRemote.App/Models/IRCommand.cs
@@ -9,8 +9,9 @@ internal class IRCommand : Command
         string? cssid = null,
         string? glyph = null,
         string? reverse = null,
-        string? speakName = null)
-        : base(name, placement, label, cssid, glyph, reverse, Phrases.Conversation_Sent(speakName ?? name))
+        string? speakName = null,
+        string? speakPhrase = null)
+        : base(name, placement, label, cssid, glyph, reverse, speakPhrase ?? Phrases.Conversation_Sent(speakName ?? name))
     {
     }
 }

--- a/src/AdaptiveRemote.App/Models/TiVoCommand.cs
+++ b/src/AdaptiveRemote.App/Models/TiVoCommand.cs
@@ -10,8 +10,9 @@ public class TiVoCommand : Command
         string? cssid = null,
         string? glyph = null,
         string? reverse = null,
-        string? speakName = null)
-        : base(name, placement, label, cssid ?? commandId, glyph, reverse, Phrases.Conversation_Sent(speakName ?? name))
+        string? speakName = null,
+        string? speakPhrase = null)
+        : base(name, placement, label, cssid ?? commandId, glyph, reverse, speakPhrase ?? Phrases.Conversation_Sent(speakName ?? name))
     {
         CommandId = commandId ?? name.ToUpperInvariant();
     }

--- a/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetOrchestrator.cs
+++ b/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetOrchestrator.cs
@@ -4,12 +4,6 @@ using Microsoft.Extensions.Hosting;
 
 namespace AdaptiveRemote.Services.CloudAssets;
 
-/// <summary>
-/// Stub orchestrator that inlines the same hardcoded commands as StaticCommandGroupProvider,
-/// expressed as a CompiledLayout DTO (without GUTTER — appended by RemoteLayoutDefinitionService).
-/// Stores the CompiledLayout in CloudAssetStore and immediately signals IPreScopeInitializer
-/// complete. No file I/O, no HTTP.
-/// </summary>
 internal class CloudAssetOrchestrator : BackgroundService, IPreScopeInitializer
 {
     private readonly ICloudAssetStore _store;
@@ -32,37 +26,37 @@ internal class CloudAssetOrchestrator : BackgroundService, IPreScopeInitializer
             [
                 new LayoutGroupDefinitionDto("DPAD",
                 [
-                    new CommandDefinitionDto(CommandType.TiVo, "Up",       "Up",       null, "Up",           "Down",      "Up"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Down",     "Down",     null, "Down",         "Up",        "Down"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Left",     "Left",     null, "Left",         "Right",     "Left"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Right",    "Right",    null, "Right",        "Left",      "Right"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Select",   "Select",   null, "Select",       null,        "Select"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Back",     "Back",     null, "Back",         null,        "Back"),
-                    new CommandDefinitionDto(CommandType.IR,   "Power",    "Power",    null, "Power",        "Power",     "Power"),
-                    new CommandDefinitionDto(CommandType.IR,   "PowerOn",  "PowerOn",  null, "PowerOn",      "PowerOff",  "PowerOn"),
-                    new CommandDefinitionDto(CommandType.IR,   "PowerOff", "PowerOff", null, "PowerOff",     "PowerOn",   "PowerOff"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Up",       "Up",       null, "Sent Up",        "Down",      "Up"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Down",     "Down",     null, "Sent Down",      "Up",        "Down"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Left",     "Left",     null, "Sent Left",      "Right",     "Left"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Right",    "Right",    null, "Sent Right",     "Left",      "Right"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Select",   "Select",   null, "Sent Select",    null,        "Select"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Back",     "Back",     null, "Sent Back",      null,        "Back"),
+                    new CommandDefinitionDto(CommandType.IR,   "Power",    "Power",    null, "Sent Power",     "Power",     "Power"),
+                    new CommandDefinitionDto(CommandType.IR,   "PowerOn",  "PowerOn",  null, "Sent PowerOn",   "PowerOff",  "PowerOn"),
+                    new CommandDefinitionDto(CommandType.IR,   "PowerOff", "PowerOff", null, "Sent PowerOff",  "PowerOn",   "PowerOff"),
                 ]),
                 new LayoutGroupDefinitionDto("WELL",
                 [
-                    new CommandDefinitionDto(CommandType.TiVo, "TiVo",    "TiVo",    null, "TiVo",    null, "TiVo"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Netflix",  "Netflix",  null, "Netflix",  null, "Netflix"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Guide",    "Guide",    null, "Guide",    null, "Guide"),
+                    new CommandDefinitionDto(CommandType.TiVo, "TiVo",    "TiVo",    null, "Sent TiVo",    null, "TiVo"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Netflix",  "Netflix",  null, "Sent Netflix",  null, "Netflix"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Guide",    "Guide",    null, "Sent Guide",    null, "Guide"),
                 ]),
                 new LayoutGroupDefinitionDto("PLAYBACK",
                 [
-                    new CommandDefinitionDto(CommandType.TiVo, "Play",   "Play",   null, "Play",   "Pause",  "Play"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Pause",  "Pause",  null, "Pause",  "Play",   "Pause"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Record", "Record", null, "Record", null,     "Record"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Skip",   "Skip",   null, "Skip",   "Replay", "Skip"),
-                    new CommandDefinitionDto(CommandType.TiVo, "Replay", "Replay", null, "Replay", "Skip",   "Replay"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Play",   "Play",   null, "Sent Play",   "Pause",  "Play"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Pause",  "Pause",  null, "Sent Pause",  "Play",   "Pause"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Record", "Record", null, "Sent Record", null,     "Record"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Skip",   "Skip",   null, "Sent Skip",   "Replay", "Skip"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Replay", "Replay", null, "Sent Replay", "Skip",   "Replay"),
                 ]),
                 new LayoutGroupDefinitionDto("CHANNELANDVOLUME",
                 [
-                    new CommandDefinitionDto(CommandType.TiVo, "ChannelUp",   "Up",   null, "Channel Up",   "ChannelDown", "ChannelUp"),
-                    new CommandDefinitionDto(CommandType.TiVo, "ChannelDown", "Down", null, "Channel Down", "ChannelUp",   "ChannelDown"),
-                    new CommandDefinitionDto(CommandType.IR,   "VolumeUp",    "Up",   null, "Volume Up",    "VolumeDown",  "VolumeUp"),
-                    new CommandDefinitionDto(CommandType.IR,   "VolumeDown",  "Down", null, "Volume Down",  "VolumeUp",    "VolumeDown"),
-                    new CommandDefinitionDto(CommandType.IR,   "Mute",        "Mute", null, "Mute",         "Mute",        "Mute"),
+                    new CommandDefinitionDto(CommandType.TiVo, "ChannelUp",   "Up",   null, "Sent Channel Up",   "ChannelDown", "ChannelUp"),
+                    new CommandDefinitionDto(CommandType.TiVo, "ChannelDown", "Down", null, "Sent Channel Down", "ChannelUp",   "ChannelDown"),
+                    new CommandDefinitionDto(CommandType.IR,   "VolumeUp",    "Up",   null, "Sent Volume Up",    "VolumeDown",  "VolumeUp"),
+                    new CommandDefinitionDto(CommandType.IR,   "VolumeDown",  "Down", null, "Sent Volume Down",  "VolumeUp",    "VolumeDown"),
+                    new CommandDefinitionDto(CommandType.IR,   "Mute",        "Mute", null, "Sent Mute",         "Mute",        "Mute"),
                 ]),
             ],
             CssDefinitions: "",

--- a/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetOrchestrator.cs
+++ b/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetOrchestrator.cs
@@ -1,13 +1,14 @@
-using AdaptiveRemote.Models;
+using AdaptiveRemote.Contracts;
 using AdaptiveRemote.Services.Lifecycle;
 using Microsoft.Extensions.Hosting;
 
 namespace AdaptiveRemote.Services.CloudAssets;
 
 /// <summary>
-/// Stub orchestrator that inlines the same hardcoded commands as StaticCommandGroupProvider.
-/// Stores the LayoutGroup root directly in CloudAssetStore and immediately signals
-/// IPreScopeInitializer complete. No file I/O, no HTTP.
+/// Stub orchestrator that inlines the same hardcoded commands as StaticCommandGroupProvider,
+/// expressed as a CompiledLayout DTO (without GUTTER — appended by RemoteLayoutDefinitionService).
+/// Stores the CompiledLayout in CloudAssetStore and immediately signals IPreScopeInitializer
+/// complete. No file I/O, no HTTP.
 /// </summary>
 internal class CloudAssetOrchestrator : BackgroundService, IPreScopeInitializer
 {
@@ -21,50 +22,51 @@ internal class CloudAssetOrchestrator : BackgroundService, IPreScopeInitializer
 
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Inline the same hardcoded layout from StaticCommandGroupProvider
-        LayoutGroup layout = new("ROOT",
-        [
-            new LayoutGroup("DPAD",
+        CompiledLayout layout = new(
+            Id: Guid.Empty,
+            RawLayoutId: Guid.Empty,
+            UserId: "stub",
+            IsActive: true,
+            Version: 1,
+            Elements:
             [
-                new TiVoCommand("Up", reverse: "Down"),
-                new TiVoCommand("Down", reverse: "Up"),
-                new TiVoCommand("Left", reverse: "Right"),
-                new TiVoCommand("Right", reverse: "Left"),
-                new TiVoCommand("Select"),
-                new TiVoCommand("Back"),
-                new IRCommand("Power", reverse: "Power"),
-                new IRCommand("PowerOn", reverse: "PowerOff"),
-                new IRCommand("PowerOff", reverse: "PowerOn"),
-            ]),
-            new LayoutGroup("WELL",
-            [
-                new TiVoCommand("TiVo"),
-                new TiVoCommand("Netflix"),
-                new TiVoCommand("Guide"),
-            ]),
-            new LayoutGroup("PLAYBACK",
-            [
-                new TiVoCommand("Play", reverse: "Pause"),
-                new TiVoCommand("Pause", reverse: "Play"),
-                new TiVoCommand("Record"),
-                new TiVoCommand("Skip", reverse: "Replay"),
-                new TiVoCommand("Replay", reverse: "Skip"),
-            ]),
-            new LayoutGroup("CHANNELANDVOLUME",
-            [
-                new TiVoCommand("ChannelUp", reverse: "ChannelDown", label: "Up", speakName: "Channel Up"),
-                new TiVoCommand("ChannelDown", reverse: "ChannelUp", label: "Down", speakName: "Channel Down"),
-                new IRCommand("VolumeUp", reverse: "VolumeDown", label: "Up", speakName: "Volume Up"),
-                new IRCommand("VolumeDown", reverse: "VolumeUp", label: "Down", speakName: "Volume Down"),
-                new IRCommand("Mute", reverse: "Mute", label: "Mute"),
-            ]),
-            new LayoutGroup("GUTTER",
-            [
-                new ConversationView(),
-                new LifecycleCommand("Learn"),
-                new LifecycleCommand("Exit", speakPhrase: Phrases.Conversation_Goodbye)
-            ])
-        ]);
+                new LayoutGroupDefinitionDto("DPAD",
+                [
+                    new CommandDefinitionDto(CommandType.TiVo, "Up",       "Up",       null, "Up",           "Down",      "Up"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Down",     "Down",     null, "Down",         "Up",        "Down"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Left",     "Left",     null, "Left",         "Right",     "Left"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Right",    "Right",    null, "Right",        "Left",      "Right"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Select",   "Select",   null, "Select",       null,        "Select"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Back",     "Back",     null, "Back",         null,        "Back"),
+                    new CommandDefinitionDto(CommandType.IR,   "Power",    "Power",    null, "Power",        "Power",     "Power"),
+                    new CommandDefinitionDto(CommandType.IR,   "PowerOn",  "PowerOn",  null, "PowerOn",      "PowerOff",  "PowerOn"),
+                    new CommandDefinitionDto(CommandType.IR,   "PowerOff", "PowerOff", null, "PowerOff",     "PowerOn",   "PowerOff"),
+                ]),
+                new LayoutGroupDefinitionDto("WELL",
+                [
+                    new CommandDefinitionDto(CommandType.TiVo, "TiVo",    "TiVo",    null, "TiVo",    null, "TiVo"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Netflix",  "Netflix",  null, "Netflix",  null, "Netflix"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Guide",    "Guide",    null, "Guide",    null, "Guide"),
+                ]),
+                new LayoutGroupDefinitionDto("PLAYBACK",
+                [
+                    new CommandDefinitionDto(CommandType.TiVo, "Play",   "Play",   null, "Play",   "Pause",  "Play"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Pause",  "Pause",  null, "Pause",  "Play",   "Pause"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Record", "Record", null, "Record", null,     "Record"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Skip",   "Skip",   null, "Skip",   "Replay", "Skip"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Replay", "Replay", null, "Replay", "Skip",   "Replay"),
+                ]),
+                new LayoutGroupDefinitionDto("CHANNELANDVOLUME",
+                [
+                    new CommandDefinitionDto(CommandType.TiVo, "ChannelUp",   "Up",   null, "Channel Up",   "ChannelDown", "ChannelUp"),
+                    new CommandDefinitionDto(CommandType.TiVo, "ChannelDown", "Down", null, "Channel Down", "ChannelUp",   "ChannelDown"),
+                    new CommandDefinitionDto(CommandType.IR,   "VolumeUp",    "Up",   null, "Volume Up",    "VolumeDown",  "VolumeUp"),
+                    new CommandDefinitionDto(CommandType.IR,   "VolumeDown",  "Down", null, "Volume Down",  "VolumeUp",    "VolumeDown"),
+                    new CommandDefinitionDto(CommandType.IR,   "Mute",        "Mute", null, "Mute",         "Mute",        "Mute"),
+                ]),
+            ],
+            CssDefinitions: "",
+            CompiledAt: DateTimeOffset.UtcNow);
 
         _store.SetLayout(layout);
         _initCompleted.SetResult();

--- a/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetStoreExtensions.cs
+++ b/src/AdaptiveRemote.App/Services/CloudAssets/CloudAssetStoreExtensions.cs
@@ -1,32 +1,14 @@
-using AdaptiveRemote.Models;
+using AdaptiveRemote.Contracts;
 
 namespace AdaptiveRemote.Services.CloudAssets;
 
-/// <summary>
-/// Extension methods for ICloudAssetStore that encapsulate asset names for common assets.
-/// </summary>
 internal static class CloudAssetStoreExtensions
 {
     private const string LayoutAssetName = "layout";
 
-    /// <summary>
-    /// Retrieves the layout asset from the store.
-    /// </summary>
-    /// <param name="store">The cloud asset store</param>
-    /// <returns>The layout group</returns>
-    /// <exception cref="InvalidOperationException">Thrown if layout not found or wrong type</exception>
-    public static LayoutGroup GetLayout(this ICloudAssetStore store)
-    {
-        return store.Get<LayoutGroup>(LayoutAssetName);
-    }
+    public static CompiledLayout GetLayout(this ICloudAssetStore store)
+        => store.Get<CompiledLayout>(LayoutAssetName);
 
-    /// <summary>
-    /// Stores the layout asset in the store.
-    /// </summary>
-    /// <param name="store">The cloud asset store</param>
-    /// <param name="layout">The layout group to store</param>
-    public static void SetLayout(this ICloudAssetStore store, LayoutGroup layout)
-    {
-        store.Set(LayoutAssetName, layout);
-    }
+    public static void SetLayout(this ICloudAssetStore store, CompiledLayout layout)
+        => store.Set(LayoutAssetName, layout);
 }

--- a/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
+++ b/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
@@ -1,38 +1,24 @@
 using AdaptiveRemote.Contracts;
 using AdaptiveRemote.Models;
-using AdaptiveRemote.Services.CloudAssets;
 
 namespace AdaptiveRemote.Services.Layout;
 
-/// <summary>
-/// RemoteLayoutDefinitionService v2: reads CompiledLayout from ICloudAssetStore,
-/// maps the element tree to runtime types per the DTO mapping table, and appends
-/// a hardcoded GUTTER as the last root child.
-/// </summary>
 internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
 {
-    private readonly Lazy<RemoteLayoutElement> _remoteRoot;
+    public RemoteLayoutElement RemoteRoot { get; }
 
-    public RemoteLayoutDefinitionService(ICloudAssetStore store)
+    public RemoteLayoutDefinitionService(CompiledLayout layout)
     {
-        _remoteRoot = new Lazy<RemoteLayoutElement>(() => BuildRoot(store));
+        RemoteRoot = BuildRoot(layout);
     }
 
-    public RemoteLayoutElement RemoteRoot => _remoteRoot.Value;
-
-    private static RemoteLayoutElement BuildRoot(ICloudAssetStore store)
+    private static RemoteLayoutElement BuildRoot(CompiledLayout layout)
     {
-        CompiledLayout layout;
-        try
-        {
-            layout = store.GetLayout();
-        }
-        catch (InvalidOperationException ex)
+        if (layout.Elements.Any(e => e.CssId == "GUTTER"))
         {
             throw new InvalidOperationException(
-                "Failed to load layout from CloudAssetStore. " +
-                "Ensure CloudAssetOrchestrator has completed initialization before the first scope is created.",
-                ex);
+                "The CompiledLayout already contains a GUTTER element. " +
+                "The client appends its own GUTTER; the server must not include one.");
         }
 
         List<RemoteLayoutElement> elements = layout.Elements
@@ -54,12 +40,12 @@ internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
             CommandType.TiVo => new TiVoCommand(
                 cmd.Name, placement: null, label: cmd.Label,
                 cssid: cmd.CssId, glyph: cmd.Glyph, reverse: cmd.Reverse,
-                speakName: cmd.SpeakPhrase),
+                speakPhrase: cmd.SpeakPhrase),
 
             CommandType.IR => new IRCommand(
                 cmd.Name, placement: null, label: cmd.Label,
                 cssid: cmd.CssId, glyph: cmd.Glyph, reverse: cmd.Reverse,
-                speakName: cmd.SpeakPhrase),
+                speakPhrase: cmd.SpeakPhrase),
 
             CommandType.Lifecycle => new LifecycleCommand(
                 cmd.Name, placement: null, label: cmd.Label,

--- a/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
+++ b/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
@@ -1,12 +1,13 @@
+using AdaptiveRemote.Contracts;
 using AdaptiveRemote.Models;
 using AdaptiveRemote.Services.CloudAssets;
 
 namespace AdaptiveRemote.Services.Layout;
 
 /// <summary>
-/// RemoteLayoutDefinitionService v1: reads LayoutGroup directly from
-/// ICloudAssetStore.Get&lt;LayoutGroup&gt;("layout") and returns it as RemoteRoot.
-/// No DTO mapping in this version.
+/// RemoteLayoutDefinitionService v2: reads CompiledLayout from ICloudAssetStore,
+/// maps the element tree to runtime types per the DTO mapping table, and appends
+/// a hardcoded GUTTER as the last root child.
 /// </summary>
 internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
 {
@@ -21,9 +22,10 @@ internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
     {
         get
         {
+            CompiledLayout layout;
             try
             {
-                return _store.GetLayout();
+                layout = _store.GetLayout();
             }
             catch (InvalidOperationException ex)
             {
@@ -32,6 +34,52 @@ internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
                     "Ensure CloudAssetOrchestrator has completed initialization before the first scope is created.",
                     ex);
             }
+
+            List<RemoteLayoutElement> elements = layout.Elements
+                .Select(MapElement)
+                .ToList();
+            elements.Add(BuildGutter());
+
+            return new LayoutGroup("ROOT", elements);
         }
     }
+
+    private static RemoteLayoutElement MapElement(LayoutElementDto dto) => dto switch
+    {
+        LayoutGroupDefinitionDto group => new LayoutGroup(
+            group.CssId,
+            group.Children.Select(MapElement).ToList()),
+
+        CommandDefinitionDto cmd => cmd.Type switch
+        {
+            CommandType.TiVo => new TiVoCommand(
+                cmd.Name, placement: null, label: cmd.Label,
+                cssid: cmd.CssId, glyph: cmd.Glyph, reverse: cmd.Reverse,
+                speakName: cmd.SpeakPhrase),
+
+            CommandType.IR => new IRCommand(
+                cmd.Name, placement: null, label: cmd.Label,
+                cssid: cmd.CssId, glyph: cmd.Glyph, reverse: cmd.Reverse,
+                speakName: cmd.SpeakPhrase),
+
+            CommandType.Lifecycle => new LifecycleCommand(
+                cmd.Name, placement: null, label: cmd.Label,
+                cssid: cmd.CssId, glyph: cmd.Glyph, reverse: cmd.Reverse,
+                speakPhrase: cmd.SpeakPhrase),
+
+            _ => throw new InvalidOperationException(
+                $"Unknown CommandType '{cmd.Type}' on command '{cmd.Name}'.")
+        },
+
+        _ => throw new InvalidOperationException(
+            $"Unknown LayoutElementDto type '{dto.GetType().Name}'.")
+    };
+
+    private static LayoutGroup BuildGutter() =>
+        new("GUTTER",
+        [
+            new ConversationView(),
+            new LifecycleCommand("Learn"),
+            new LifecycleCommand("Exit", speakPhrase: Phrases.Conversation_Goodbye),
+        ]);
 }

--- a/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
+++ b/src/AdaptiveRemote.App/Services/Layout/RemoteLayoutDefinitionService.cs
@@ -11,37 +11,36 @@ namespace AdaptiveRemote.Services.Layout;
 /// </summary>
 internal class RemoteLayoutDefinitionService : IRemoteDefinitionService
 {
-    private readonly ICloudAssetStore _store;
+    private readonly Lazy<RemoteLayoutElement> _remoteRoot;
 
     public RemoteLayoutDefinitionService(ICloudAssetStore store)
     {
-        _store = store;
+        _remoteRoot = new Lazy<RemoteLayoutElement>(() => BuildRoot(store));
     }
 
-    public RemoteLayoutElement RemoteRoot
+    public RemoteLayoutElement RemoteRoot => _remoteRoot.Value;
+
+    private static RemoteLayoutElement BuildRoot(ICloudAssetStore store)
     {
-        get
+        CompiledLayout layout;
+        try
         {
-            CompiledLayout layout;
-            try
-            {
-                layout = _store.GetLayout();
-            }
-            catch (InvalidOperationException ex)
-            {
-                throw new InvalidOperationException(
-                    "Failed to load layout from CloudAssetStore. " +
-                    "Ensure CloudAssetOrchestrator has completed initialization before the first scope is created.",
-                    ex);
-            }
-
-            List<RemoteLayoutElement> elements = layout.Elements
-                .Select(MapElement)
-                .ToList();
-            elements.Add(BuildGutter());
-
-            return new LayoutGroup("ROOT", elements);
+            layout = store.GetLayout();
         }
+        catch (InvalidOperationException ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to load layout from CloudAssetStore. " +
+                "Ensure CloudAssetOrchestrator has completed initialization before the first scope is created.",
+                ex);
+        }
+
+        List<RemoteLayoutElement> elements = layout.Elements
+            .Select(MapElement)
+            .ToList();
+        elements.Add(BuildGutter());
+
+        return new LayoutGroup("ROOT", elements);
     }
 
     private static RemoteLayoutElement MapElement(LayoutElementDto dto) => dto switch

--- a/test/AdaptiveRemote.App.Tests/Services/Layout/RemoteLayoutDefinitionServiceTests.cs
+++ b/test/AdaptiveRemote.App.Tests/Services/Layout/RemoteLayoutDefinitionServiceTests.cs
@@ -1,22 +1,12 @@
 using AdaptiveRemote.Contracts;
 using AdaptiveRemote.Models;
-using AdaptiveRemote.Services.CloudAssets;
 using FluentAssertions;
-using Moq;
 
 namespace AdaptiveRemote.Services.Layout;
 
 [TestClass]
 public class RemoteLayoutDefinitionServiceTests
 {
-    private readonly Mock<ICloudAssetStore> _mockStore = new();
-
-    [TestCleanup]
-    public void VerifyMocks()
-    {
-        _mockStore.Verify();
-    }
-
     private static CompiledLayout MakeLayout(params LayoutElementDto[] elements) =>
         new(Guid.Empty, Guid.Empty, "stub", true, 1, elements, "", DateTimeOffset.UtcNow);
 
@@ -27,11 +17,10 @@ public class RemoteLayoutDefinitionServiceTests
         CompiledLayout layout = MakeLayout(
             new LayoutGroupDefinitionDto("GROUP",
             [
-                new CommandDefinitionDto(CommandType.TiVo, "Play", "Play", null, "Play", "Pause", "Play"),
+                new CommandDefinitionDto(CommandType.TiVo, "Play", "Play", null, "Sent Play", "Pause", "Play"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
@@ -41,6 +30,7 @@ public class RemoteLayoutDefinitionServiceTests
         // Assert
         cmd.Name.Should().Be("Play");
         cmd.Reverse.Should().Be("Pause");
+        cmd.SpeakPhrase.Should().Be("Sent Play");
     }
 
     [TestMethod]
@@ -50,11 +40,10 @@ public class RemoteLayoutDefinitionServiceTests
         CompiledLayout layout = MakeLayout(
             new LayoutGroupDefinitionDto("GROUP",
             [
-                new CommandDefinitionDto(CommandType.IR, "VolumeUp", "Up", null, "Volume Up", "VolumeDown", "VolumeUp"),
+                new CommandDefinitionDto(CommandType.IR, "VolumeUp", "Up", null, "Sent Volume Up", "VolumeDown", "VolumeUp"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
@@ -64,6 +53,7 @@ public class RemoteLayoutDefinitionServiceTests
         // Assert
         cmd.Should().BeOfType<IRCommand>();
         cmd.As<IRCommand>().Name.Should().Be("VolumeUp");
+        cmd.As<IRCommand>().SpeakPhrase.Should().Be("Sent Volume Up");
     }
 
     [TestMethod]
@@ -75,9 +65,8 @@ public class RemoteLayoutDefinitionServiceTests
             [
                 new CommandDefinitionDto(CommandType.Lifecycle, "Exit", "Exit", null, "Goodbye", null, "Exit"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
@@ -96,12 +85,11 @@ public class RemoteLayoutDefinitionServiceTests
         CompiledLayout layout = MakeLayout(
             new LayoutGroupDefinitionDto("DPAD",
             [
-                new CommandDefinitionDto(CommandType.TiVo, "Up",   "Up",   null, "Up",   "Down", "Up"),
-                new CommandDefinitionDto(CommandType.TiVo, "Down", "Down", null, "Down", "Up",   "Down"),
+                new CommandDefinitionDto(CommandType.TiVo, "Up",   "Up",   null, "Sent Up",   "Down", "Up"),
+                new CommandDefinitionDto(CommandType.TiVo, "Down", "Down", null, "Sent Down", "Up",   "Down"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
@@ -119,11 +107,10 @@ public class RemoteLayoutDefinitionServiceTests
         CompiledLayout layout = MakeLayout(
             new LayoutGroupDefinitionDto("DPAD",
             [
-                new CommandDefinitionDto(CommandType.TiVo, "Up", "Up", null, "Up", null, "Up"),
+                new CommandDefinitionDto(CommandType.TiVo, "Up", "Up", null, "Sent Up", null, "Up"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
@@ -152,12 +139,9 @@ public class RemoteLayoutDefinitionServiceTests
             [
                 new CommandDefinitionDto((CommandType)99, "Unknown", "Unknown", null, "Unknown", null, "Unknown"),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
-
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
 
         // Act
-        Action act = () => _ = sut.RemoteRoot;
+        Action act = () => _ = new RemoteLayoutDefinitionService(layout);
 
         // Assert
         act.Should().Throw<InvalidOperationException>()
@@ -165,21 +149,21 @@ public class RemoteLayoutDefinitionServiceTests
     }
 
     [TestMethod]
-    public void RemoteLayoutDefinitionService_RemoteRoot_EmptyStoreThrowsDescriptiveError()
+    public void RemoteLayoutDefinitionService_RemoteRoot_GutterInLayoutThrowsDescriptiveError()
     {
         // Arrange
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout"))
-            .Throws(new InvalidOperationException("Asset 'layout' not found in store."))
-            .Verifiable();
-
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("GUTTER",
+            [
+                new CommandDefinitionDto(CommandType.Lifecycle, "Exit", "Exit", null, "Goodbye", null, "Exit"),
+            ]));
 
         // Act
-        Action act = () => _ = sut.RemoteRoot;
+        Action act = () => _ = new RemoteLayoutDefinitionService(layout);
 
         // Assert
         act.Should().Throw<InvalidOperationException>()
-            .WithMessage("Failed to load layout from CloudAssetStore.*");
+            .WithMessage("*already contains a GUTTER*");
     }
 
     [TestMethod]
@@ -191,12 +175,11 @@ public class RemoteLayoutDefinitionServiceTests
             [
                 new LayoutGroupDefinitionDto("INNER",
                 [
-                    new CommandDefinitionDto(CommandType.TiVo, "Select", "Select", null, "Select", null, "Select"),
+                    new CommandDefinitionDto(CommandType.TiVo, "Select", "Select", null, "Sent Select", null, "Select"),
                 ]),
             ]));
-        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+        RemoteLayoutDefinitionService sut = new(layout);
 
         // Act
         LayoutGroup root = (LayoutGroup)sut.RemoteRoot;

--- a/test/AdaptiveRemote.App.Tests/Services/Layout/RemoteLayoutDefinitionServiceTests.cs
+++ b/test/AdaptiveRemote.App.Tests/Services/Layout/RemoteLayoutDefinitionServiceTests.cs
@@ -1,3 +1,4 @@
+using AdaptiveRemote.Contracts;
 using AdaptiveRemote.Models;
 using AdaptiveRemote.Services.CloudAssets;
 using FluentAssertions;
@@ -16,29 +17,158 @@ public class RemoteLayoutDefinitionServiceTests
         _mockStore.Verify();
     }
 
+    private static CompiledLayout MakeLayout(params LayoutElementDto[] elements) =>
+        new(Guid.Empty, Guid.Empty, "stub", true, 1, elements, "", DateTimeOffset.UtcNow);
+
     [TestMethod]
-    public void RemoteLayoutDefinitionService_RemoteRoot_ReturnsStoreContents()
+    public void RemoteLayoutDefinitionService_RemoteRoot_MapsTiVoCommandCorrectly()
     {
         // Arrange
-        LayoutGroup expectedLayout = new("ROOT", []);
-        _mockStore.Setup(s => s.Get<LayoutGroup>("layout"))
-            .Returns(expectedLayout)
-            .Verifiable();
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("GROUP",
+            [
+                new CommandDefinitionDto(CommandType.TiVo, "Play", "Play", null, "Play", "Pause", "Play"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
         RemoteLayoutDefinitionService sut = new(_mockStore.Object);
 
         // Act
-        RemoteLayoutElement actualRoot = sut.RemoteRoot;
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        LayoutGroup group = (LayoutGroup)root.Elements.First();
+        TiVoCommand cmd = (TiVoCommand)group.Elements.First();
 
         // Assert
-        actualRoot.Should().BeSameAs(expectedLayout);
+        cmd.Name.Should().Be("Play");
+        cmd.Reverse.Should().Be("Pause");
+    }
+
+    [TestMethod]
+    public void RemoteLayoutDefinitionService_RemoteRoot_MapsIRCommandCorrectly()
+    {
+        // Arrange
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("GROUP",
+            [
+                new CommandDefinitionDto(CommandType.IR, "VolumeUp", "Up", null, "Volume Up", "VolumeDown", "VolumeUp"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
+
+        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+
+        // Act
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        LayoutGroup group = (LayoutGroup)root.Elements.First();
+        RemoteLayoutElement cmd = group.Elements.First();
+
+        // Assert
+        cmd.Should().BeOfType<IRCommand>();
+        cmd.As<IRCommand>().Name.Should().Be("VolumeUp");
+    }
+
+    [TestMethod]
+    public void RemoteLayoutDefinitionService_RemoteRoot_MapsLifecycleCommandCorrectly()
+    {
+        // Arrange
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("GROUP",
+            [
+                new CommandDefinitionDto(CommandType.Lifecycle, "Exit", "Exit", null, "Goodbye", null, "Exit"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
+
+        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+
+        // Act
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        LayoutGroup group = (LayoutGroup)root.Elements.First();
+        RemoteLayoutElement cmd = group.Elements.First();
+
+        // Assert
+        cmd.Should().BeOfType<LifecycleCommand>();
+        cmd.As<LifecycleCommand>().Name.Should().Be("Exit");
+    }
+
+    [TestMethod]
+    public void RemoteLayoutDefinitionService_RemoteRoot_MapsLayoutGroupCorrectly()
+    {
+        // Arrange
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("DPAD",
+            [
+                new CommandDefinitionDto(CommandType.TiVo, "Up",   "Up",   null, "Up",   "Down", "Up"),
+                new CommandDefinitionDto(CommandType.TiVo, "Down", "Down", null, "Down", "Up",   "Down"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
+
+        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+
+        // Act
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        LayoutGroup dpad = (LayoutGroup)root.Elements.First();
+
+        // Assert
+        dpad.CSSID.Should().Be("DPAD");
+        dpad.Elements.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public void RemoteLayoutDefinitionService_RemoteRoot_GutterAlwaysAppendedAsLastChild()
+    {
+        // Arrange
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("DPAD",
+            [
+                new CommandDefinitionDto(CommandType.TiVo, "Up", "Up", null, "Up", null, "Up"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
+
+        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+
+        // Act
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        RemoteLayoutElement lastChild = root.Elements.Last();
+
+        // Assert
+        lastChild.Should().BeOfType<LayoutGroup>();
+        LayoutGroup gutter = (LayoutGroup)lastChild;
+        gutter.CSSID.Should().Be("GUTTER");
+
+        List<RemoteLayoutElement> gutterElements = gutter.Elements.ToList();
+        gutterElements.Should().HaveCount(3);
+        gutterElements[0].Should().BeOfType<ConversationView>();
+        gutterElements[1].Should().BeOfType<LifecycleCommand>()
+            .Which.Name.Should().Be("Learn");
+        gutterElements[2].Should().BeOfType<LifecycleCommand>()
+            .Which.Name.Should().Be("Exit");
+    }
+
+    [TestMethod]
+    public void RemoteLayoutDefinitionService_RemoteRoot_UnknownCommandTypeThrows()
+    {
+        // Arrange
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("GROUP",
+            [
+                new CommandDefinitionDto((CommandType)99, "Unknown", "Unknown", null, "Unknown", null, "Unknown"),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
+
+        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
+
+        // Act
+        Action act = () => _ = sut.RemoteRoot;
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Unknown CommandType*");
     }
 
     [TestMethod]
     public void RemoteLayoutDefinitionService_RemoteRoot_EmptyStoreThrowsDescriptiveError()
     {
         // Arrange
-        _mockStore.Setup(s => s.Get<LayoutGroup>("layout"))
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout"))
             .Throws(new InvalidOperationException("Asset 'layout' not found in store."))
             .Verifiable();
 
@@ -53,50 +183,29 @@ public class RemoteLayoutDefinitionServiceTests
     }
 
     [TestMethod]
-    public void RemoteLayoutDefinitionService_RemoteRoot_WrongTypeThrowsDescriptiveError()
+    public void RemoteLayoutDefinitionService_RemoteRoot_MapsNestedGroupsRecursively()
     {
         // Arrange
-        _mockStore.Setup(s => s.Get<LayoutGroup>("layout"))
-            .Throws(new InvalidOperationException("Asset 'layout' is of type 'String', but 'LayoutGroup' was requested."))
-            .Verifiable();
+        CompiledLayout layout = MakeLayout(
+            new LayoutGroupDefinitionDto("OUTER",
+            [
+                new LayoutGroupDefinitionDto("INNER",
+                [
+                    new CommandDefinitionDto(CommandType.TiVo, "Select", "Select", null, "Select", null, "Select"),
+                ]),
+            ]));
+        _mockStore.Setup(s => s.Get<CompiledLayout>("layout")).Returns(layout).Verifiable();
 
         RemoteLayoutDefinitionService sut = new(_mockStore.Object);
 
         // Act
-        Action act = () => _ = sut.RemoteRoot;
+        LayoutGroup root = (LayoutGroup)sut.RemoteRoot;
+        LayoutGroup outer = (LayoutGroup)root.Elements.First();
+        LayoutGroup inner = (LayoutGroup)outer.Elements.First();
 
         // Assert
-        act.Should().Throw<InvalidOperationException>()
-            .WithMessage("Failed to load layout from CloudAssetStore.*");
-    }
-
-    [TestMethod]
-    public void RemoteLayoutDefinitionService_RemoteRoot_ReturnsComplexLayout()
-    {
-        // Arrange
-        LayoutGroup expectedLayout = new("ROOT",
-        [
-            new LayoutGroup("GROUP1",
-            [
-                new TiVoCommand("Up"),
-                new TiVoCommand("Down"),
-            ]),
-            new LayoutGroup("GROUP2",
-            [
-                new IRCommand("Power"),
-            ])
-        ]);
-
-        _mockStore.Setup(s => s.Get<LayoutGroup>("layout"))
-            .Returns(expectedLayout)
-            .Verifiable();
-
-        RemoteLayoutDefinitionService sut = new(_mockStore.Object);
-
-        // Act
-        RemoteLayoutElement actualRoot = sut.RemoteRoot;
-
-        // Assert
-        actualRoot.Should().BeSameAs(expectedLayout);
+        outer.CSSID.Should().Be("OUTER");
+        inner.CSSID.Should().Be("INNER");
+        inner.Elements.First().Should().BeOfType<TiVoCommand>();
     }
 }


### PR DESCRIPTION
Implements client-side consumption of CompiledLayout by mapping layout DTOs (AdaptiveRemote.Contracts) into the runtime RemoteLayoutElement model tree used by the app, with updated stub orchestration and unit tests.