### PR TITLE
Apply ADR-187 dev experience requirements to RawLayoutService

### DIFF
--- a/src/AdaptiveRemote.Backend.RawLayoutService/AdaptiveRemote.Backend.RawLayoutService.csproj
+++ b/src/AdaptiveRemote.Backend.RawLayoutService/AdaptiveRemote.Backend.RawLayoutService.csproj
@@ -5,10 +5,13 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>AdaptiveRemote.Backend.RawLayoutService</RootNamespace>
+    <UserSecretsId>7c4a1f2e-b839-4d6a-9e0c-f521da3b8c47</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
     <PackageReference Include="AWSSDK.DynamoDBv2" />
   </ItemGroup>
 

--- a/src/AdaptiveRemote.Backend.RawLayoutService/Logging/MessageLogger.cs
+++ b/src/AdaptiveRemote.Backend.RawLayoutService/Logging/MessageLogger.cs
@@ -63,4 +63,10 @@ public static partial class MessageLogger
 
     [LoggerMessage(EventId = 1217, Level = LogLevel.Error, Message = "Error processing health check request")]
     public static partial void ErrorProcessingHealthCheck(this ILogger logger, Exception exception);
+
+    [LoggerMessage(
+        EventId = 1218,
+        Level = LogLevel.Error,
+        Message = "LocalStack dependency check failed at {HealthUrl}: {FailureReason}. LocalStack is required for local development. See docs/local-dev.md for setup instructions")]
+    public static partial void LocalStackDependencyUnavailable(this ILogger logger, string healthUrl, string failureReason, Exception? exception);
 }

--- a/src/AdaptiveRemote.Backend.RawLayoutService/Program.cs
+++ b/src/AdaptiveRemote.Backend.RawLayoutService/Program.cs
@@ -9,6 +9,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Scalar.AspNetCore;
+using System.Net.Http;
+using System.Text.Json;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -97,14 +100,27 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     });
 
 builder.Services.AddAuthorization();
+builder.Services.AddOpenApi();
 
 WebApplication app = builder.Build();
 
 ILogger<Program> logger = app.Services.GetRequiredService<ILogger<Program>>();
 logger.ServiceStarting();
 
+if (app.Environment.IsDevelopment())
+{
+    await EnsureLocalStackRunningAsync(app, logger).ConfigureAwait(false);
+}
+
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapOpenApi();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapScalarApiReference();
+}
 
 // Map endpoints
 app.MapHealthEndpoints();
@@ -118,6 +134,112 @@ string listenAddress = app.Configuration["ASPNETCORE_URLS"]
 logger.ServiceStarted(listenAddress);
 
 app.Run();
+
+static async Task EnsureLocalStackRunningAsync(WebApplication app, ILogger logger)
+{
+    const int LocalStackHealthCheckTimeoutSeconds = 5;
+    const int LocalStackStartupWaitTimeoutSeconds = 30;
+    const int LocalStackRetryDelaySeconds = 2;
+    TimeSpan localStackStartupWaitTimeout = TimeSpan.FromSeconds(LocalStackStartupWaitTimeoutSeconds);
+    TimeSpan localStackRetryDelay = TimeSpan.FromSeconds(LocalStackRetryDelaySeconds);
+    string[] requiredServices = ["dynamodb"];
+
+    string baseUrl = app.Configuration["LocalStack:BaseUrl"] ?? "http://localhost:4566";
+
+    if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out Uri? baseUri))
+    {
+        logger.LocalStackDependencyUnavailable(baseUrl, "configuration value is not a valid absolute URL", exception: null);
+        Environment.Exit(1);
+    }
+
+    Uri healthUri = new(baseUri, "/_localstack/health");
+
+    using HttpClient client = new() { Timeout = TimeSpan.FromSeconds(LocalStackHealthCheckTimeoutSeconds) };
+    Exception? lastException = null;
+    string? lastFailureReason = null;
+    DateTime deadlineUtc = DateTime.UtcNow.Add(localStackStartupWaitTimeout);
+
+    while (DateTime.UtcNow < deadlineUtc)
+    {
+        try
+        {
+            using HttpResponseMessage response = await client.GetAsync(healthUri).ConfigureAwait(false);
+            string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                lastFailureReason = $"HTTP {(int)response.StatusCode}";
+            }
+            else
+            {
+                using JsonDocument json = JsonDocument.Parse(body);
+                if (IsLocalStackRunning(json.RootElement, requiredServices, out string failureReason))
+                {
+                    return;
+                }
+
+                lastFailureReason = failureReason;
+            }
+
+            lastException = null;
+        }
+        catch (Exception ex)
+        {
+            lastException = ex;
+            lastFailureReason = ex.Message;
+        }
+
+        await Task.Delay(localStackRetryDelay).ConfigureAwait(false);
+    }
+
+    logger.LocalStackDependencyUnavailable(
+        healthUri.ToString(),
+        $"did not become healthy within {LocalStackStartupWaitTimeoutSeconds}s; last check result: {lastFailureReason ?? "unknown health check failure"}",
+        lastException);
+    Environment.Exit(1);
+}
+
+static bool IsLocalStackRunning(JsonElement root, IReadOnlyList<string> requiredServices, out string failureReason)
+{
+    if (root.TryGetProperty("status", out JsonElement statusElement))
+    {
+        string status = statusElement.GetString() ?? string.Empty;
+        if (string.Equals(status, "running", StringComparison.OrdinalIgnoreCase))
+        {
+            failureReason = string.Empty;
+            return true;
+        }
+
+        failureReason = $"status='{status}'";
+        return false;
+    }
+
+    if (!root.TryGetProperty("services", out JsonElement servicesElement) || servicesElement.ValueKind != JsonValueKind.Object)
+    {
+        failureReason = "health response did not contain a running status or services object";
+        return false;
+    }
+
+    foreach (string service in requiredServices)
+    {
+        if (!servicesElement.TryGetProperty(service, out JsonElement serviceStatusElement))
+        {
+            failureReason = $"service '{service}' was missing from health response";
+            return false;
+        }
+
+        string serviceStatus = serviceStatusElement.GetString() ?? string.Empty;
+        if (!string.Equals(serviceStatus, "available", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(serviceStatus, "running", StringComparison.OrdinalIgnoreCase))
+        {
+            failureReason = $"service '{service}' status was '{serviceStatus}'";
+            return false;
+        }
+    }
+
+    failureReason = string.Empty;
+    return true;
+}
 
 // Make Program visible for testing
 public partial class Program { }

--- a/src/AdaptiveRemote.Backend.RawLayoutService/Properties/launchSettings.json
+++ b/src/AdaptiveRemote.Backend.RawLayoutService/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "profiles": {
+    "Development": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "scalar",
+      "outputCapture": "None",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:54435;http://localhost:54436"
+    },
+    "AdaptiveRemote.Backend.RawLayoutService": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "scalar",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:54435;http://localhost:54436"
+    }
+  }
+}

--- a/src/AdaptiveRemote.Backend.RawLayoutService/appsettings.Development.json
+++ b/src/AdaptiveRemote.Backend.RawLayoutService/appsettings.Development.json
@@ -6,8 +6,11 @@
     }
   },
   "DynamoDB": {
-    "ServiceUrl": "http://localstack:4566",
+    "ServiceUrl": "http://localhost:4566",
     "TableName": "RawLayouts",
     "Region": "us-east-1"
+  },
+  "LocalStack": {
+    "BaseUrl": "http://localhost:4566"
   }
 }


### PR DESCRIPTION
Retrofits RawLayoutService to match the standing pattern established by Task 5 (ADR-187) and already present on CompiledLayoutService:

- Add Microsoft.AspNetCore.OpenApi and Scalar.AspNetCore packages; register Scalar UI at /scalar guarded by IsDevelopment()
- Add Properties/launchSettings.json with a Development profile that sets outputCapture=None so F5 in VS opens a separate console window
- On startup (development only), ping /_localstack/health and exit non-zero with an actionable error message if LocalStack/DynamoDB is unavailable
- Add LocalStackDependencyUnavailable [LoggerMessage] at event ID 1218
- Fix appsettings.Development.json: DynamoDB:ServiceUrl and LocalStack:BaseUrl now default to http://localhost:4566 for dotnet run on the host; docker-compose overrides both with the Docker-internal hostname via environment variables

https://claude.ai/code/session_01FS4j5bZtV231FNpw4sJuab