### PR TITLE
Update OpenTelemetry.Exporter packages to 1.15.3 to fix GHSA-4625-4j76-fww9

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,8 +14,8 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <!-- OpenTelemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <!-- Third-party Libraries -->
     <PackageVersion Include="I8Beef.TiVo" Version="1.0.0.14" />


### PR DESCRIPTION
Cherry-pick from 465de1b967d36c262324fdbf80bdd530e5b968fe

Agent-Logs-Url: https://github.com/jodavis/AdaptiveRemote/sessions/2a25fc1c-dd69-4762-a4d7-4c87cf614e29