### PR TITLE
ADR-227: Add BackgroundNoiseAugmentor and MicrophoneNoiseAugmentor stages

### DIFF
--- a/ml/params.yaml
+++ b/ml/params.yaml
@@ -2,6 +2,7 @@ pipeline:
   input_phrases_path: scripts/intent_prediction/01_input_phrases.csv
   variations_per_phrase: 20
   subsample_rate: 200
+  sample_rate: 16000
 
 stages:
   generate_phrases:

--- a/ml/params.yaml
+++ b/ml/params.yaml
@@ -20,3 +20,11 @@ stages:
     suffix_vary_probability: 0.333
     suffix_min_s: 0.1
     suffix_max_s: 0.5
+  add_background_noise:
+    vary_probability: 0.5
+    volume_min: 0.0
+    volume_max: 0.3
+  add_mic_noise:
+    vary_probability: 0.5
+    amplitude_min: 0.001
+    amplitude_max: 0.05

--- a/ml/pipeline/speech/_doc_speech.md
+++ b/ml/pipeline/speech/_doc_speech.md
@@ -10,9 +10,10 @@ produces a derived `AudioSample` manifest with per-sample variation applied.
 |--------|-------------|-----------|
 | [`tts_stage.py`](tts_stage.py) | `TtsSampleGenerator` | `TextSample → AudioSample` via edge_tts |
 | [`delay_stage.py`](delay_stage.py) | `DelayAugmentor` | `AudioSample → AudioSample` (silence padding) |
+| [`background_noise_stage.py`](background_noise_stage.py) | `BackgroundNoiseAugmentor` | `AudioSample → AudioSample` (environmental noise mix) |
+| [`mic_noise_stage.py`](mic_noise_stage.py) | `MicrophoneNoiseAugmentor` | `AudioSample → AudioSample` (Gaussian mic noise) |
 
-Planned stages (not yet implemented): `background_noise_stage.py`,
-`mic_noise_stage.py`, `token_stage.py`, `spectrogram_stage.py`.
+Planned stages (not yet implemented): `token_stage.py`, `spectrogram_stage.py`.
 
 ## Key design decisions
 
@@ -36,3 +37,22 @@ prefix for the same reason.
 accepts `list[str]` voices directly. The entry-point runs `asyncio.run(edge_tts.list_voices())`
 and filters: `Gender == 'Female'`, `Locale == 'en-US'`, `':' not in ShortName`,
 `'DragonHD' not in ShortName`, `'Turbo' not in ShortName`.
+
+**`NoiseProvider` protocol as the noise-file seam for `BackgroundNoiseAugmentor`.**
+Consistent with `TtsProvider` in `tts_stage.py` — the protocol lives in the same
+module as the stage that uses it. Unit tests supply `_FakeNoiseProvider`; the
+entry-point supplies `_DirectoryNoiseProvider` (globbing `*.wav` from `--noise-dir`).
+
+**`noise_file` is always chosen (hash stability), `noise_start_s`/`noise_volume` are
+0.0 when not applied.** `VariationGenerator.choose()` runs on the sorted filename list
+before the `should_vary` check so the content hash does not change if `vary_probability`
+is toggled. All three keys are always present in `applied_values`.
+
+**`noise_start_s` bounds are derived from file durations at runtime.** Both the noise
+file and the audio sample file are read in `_get_applied_values` when noise is applied.
+`max_start_s = noise_duration_s - audio_duration_s`; clamped to 0.0 when negative
+(i.e. noise file is shorter than audio).
+
+**Gaussian noise in `MicrophoneNoiseAugmentor` is seeded from `output_seed`.** Uses
+`np.random.default_rng(output_seed).normal(0, amplitude, len(samples))` for
+reproducibility. The amplitude is stored as 0.0 when not applied.

--- a/ml/pipeline/speech/_doc_speech.md
+++ b/ml/pipeline/speech/_doc_speech.md
@@ -43,15 +43,11 @@ Consistent with `TtsProvider` in `tts_stage.py` — the protocol lives in the sa
 module as the stage that uses it. Unit tests supply `_FakeNoiseProvider`; the
 entry-point supplies `_DirectoryNoiseProvider` (globbing `*.wav` from `--noise-dir`).
 
-**`noise_file` is always chosen (hash stability), `noise_start_s`/`noise_volume` are
-0.0 when not applied.** `VariationGenerator.choose()` runs on the sorted filename list
-before the `should_vary` check so the content hash does not change if `vary_probability`
-is toggled. All three keys are always present in `applied_values`.
-
-**`noise_start_s` bounds are derived from file durations at runtime.** Both the noise
-file and the audio sample file are read in `_get_applied_values` when noise is applied.
-`max_start_s = noise_duration_s - audio_duration_s`; clamped to 0.0 when negative
-(i.e. noise file is shorter than audio).
+**`noise_file` is always chosen (hash stability), `noise_volume` is 0.0 when not applied.**
+`VariationGenerator.choose()` runs on the sorted filename list before the `should_vary`
+check so the content hash does not change if `vary_probability` is toggled. All three
+keys (`noise_file`, `noise_start_s`, `noise_volume`) are always present in `applied_values`.
+`noise_start_s` is always 0.0 — noise is mixed from the beginning of the noise file.
 
 **Gaussian noise in `MicrophoneNoiseAugmentor` is seeded from `output_seed`.** Uses
 `np.random.default_rng(output_seed).normal(0, amplitude, len(samples))` for

--- a/ml/pipeline/speech/background_noise_stage.py
+++ b/ml/pipeline/speech/background_noise_stage.py
@@ -17,13 +17,17 @@ from pipeline.stages.params import AddBackgroundNoiseParams
 
 
 class NoiseProvider(Protocol):
-    """Protocol for listing available noise files.
+    """Protocol for supplying pre-loaded noise audio data.
 
-    Consistent with TtsProvider living in tts_stage.py — the protocol belongs
-    alongside the stage that uses it.
+    Implementations load and resample noise files at construction time so that
+    each call to list_files() is cheap and all returned audio uses the same
+    sample rate.
+
+    Returns a list of (filename, AudioData) pairs. The filename is used for
+    hash-stable variation selection; AudioData is used for mixing.
     """
 
-    def list_files(self) -> list[Path]: ...
+    def list_files(self) -> list[tuple[str, AudioData]]: ...
 
 
 class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
@@ -34,7 +38,10 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     noise_volume is set to 0.0 when the noise is not applied. noise_start_s
     is always 0.0 (noise always mixed from the start of the noise file).
 
-    Noise mixing: slice noise at noise_start_s for len(audio) samples,
+    When noise_volume == 0.0, the input sample is returned unchanged — no
+    file is written and no I/O occurs.
+
+    Noise mixing (when applied): slice noise for len(audio) samples,
     zero-pad if noise is shorter, multiply by noise_volume, add, clip to [-1.0, 1.0].
     """
 
@@ -45,7 +52,6 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         audio_reader: AudioReader,
         audio_writer: AudioWriter,
         input_dir: Path,
-        noise_dir: Path,
         noise_provider: NoiseProvider,
         params: AddBackgroundNoiseParams,
     ) -> None:
@@ -53,7 +59,6 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         self._audio_reader = audio_reader
         self._audio_writer = audio_writer
         self._input_dir = input_dir
-        self._noise_dir = noise_dir
         self._noise_provider = noise_provider
         self._vary_probability = params.vary_probability
         self._volume_filter = MinMaxFilter(params.volume_min, params.volume_max, precision=2)
@@ -62,9 +67,9 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         self, sample: AudioSample, generator: VariationGenerator
     ) -> dict[str, Any]:
         # Always choose a noise file for hash stability, even when not applied.
-        # list_files() is called once; _noise_dir resolves the full path.
-        noise_files = sorted([p.name for p in self._noise_provider.list_files()])
-        noise_file: str = generator.choose("noise_file", noise_files)
+        # list_files() returns pre-loaded (name, AudioData) pairs.
+        noise_items = self._noise_provider.list_files()
+        noise_file: str = generator.choose("noise_file", sorted([name for name, _ in noise_items]))
 
         if generator.should_vary("noise", self._vary_probability):
             noise_volume = generator.generate("noise_volume", self._volume_filter)
@@ -91,30 +96,41 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         applied_values: dict[str, Any],
         parent_content_hash: str,
     ) -> AudioSample:
+        noise_volume: float = applied_values["noise_volume"]
+
+        # When not applied, return the input sample unchanged — no I/O.
+        if noise_volume == 0.0:
+            return input_sample
+
         noise_file: str = applied_values["noise_file"]
         noise_start_s: float = applied_values["noise_start_s"]
-        noise_volume: float = applied_values["noise_volume"]
 
         input_path = self._input_dir / input_sample.path
         audio = await self._audio_reader.read(input_path)
 
-        if noise_volume > 0.0:
-            noise_path = self._noise_dir / noise_file
-            noise_audio = await self._audio_reader.read(noise_path)
+        # Look up the pre-loaded noise audio from the provider.
+        noise_items = self._noise_provider.list_files()
+        noise_audio = next(data for name, data in noise_items if name == noise_file)
 
-            start_sample = int(noise_start_s * noise_audio.sample_rate)
-            n_needed = len(audio.samples)
-            noise_slice = noise_audio.samples[start_sample: start_sample + n_needed]
+        if noise_audio.sample_rate != audio.sample_rate:
+            raise ValueError(
+                f"Noise file '{noise_file}' has sample_rate {noise_audio.sample_rate} Hz "
+                f"but input audio has sample_rate {audio.sample_rate} Hz. "
+                f"Configure _DirectoryNoiseProvider with the pipeline sample_rate so that "
+                f"noise files are resampled at load time."
+            )
 
-            # Zero-pad if noise slice is shorter than audio
-            if len(noise_slice) < n_needed:
-                noise_slice = np.pad(noise_slice, (0, n_needed - len(noise_slice)))
+        start_sample = int(noise_start_s * noise_audio.sample_rate)
+        n_needed = len(audio.samples)
+        noise_slice = noise_audio.samples[start_sample: start_sample + n_needed]
 
-            output_samples: np.ndarray = np.clip(
-                audio.samples + noise_volume * noise_slice, -1.0, 1.0
-            ).astype(np.float32)
-        else:
-            output_samples = audio.samples
+        # Zero-pad if noise slice is shorter than audio
+        if len(noise_slice) < n_needed:
+            noise_slice = np.pad(noise_slice, (0, n_needed - len(noise_slice)))
+
+        output_samples: np.ndarray = np.clip(
+            audio.samples + noise_volume * noise_slice, -1.0, 1.0
+        ).astype(np.float32)
 
         self._output_dir.mkdir(parents=True, exist_ok=True)
         output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")

--- a/ml/pipeline/speech/background_noise_stage.py
+++ b/ml/pipeline/speech/background_noise_stage.py
@@ -1,0 +1,181 @@
+"""BackgroundNoiseAugmentor: mix environmental noise into WAV audio samples.
+
+noise_file is always chosen (choose() always called) for hash stability, even when
+not applied. noise_start_s and noise_volume are stored as 0.0 when should_vary
+returns False. All three keys (noise_file, noise_start_s, noise_volume) are always
+present in every applied_values dict.
+
+noise_start_s bounds are derived from file durations: both the noise file and the
+audio sample file are read to compute max_start_s = noise_duration_s - audio_duration_s.
+When the noise file is shorter than the audio sample, max_start_s is negative and
+clamped to 0.0 (min and max both 0.0).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.core.modifier_stage import ModifierStage
+from pipeline.core.randomization import MinMaxFilter, VariationGenerator
+from pipeline.core.sample import AudioSample
+from pipeline.io.audio_io import AudioData, AudioReader, AudioWriter
+from pipeline.stages import conventions
+from pipeline.stages.params import AddBackgroundNoiseParams
+
+
+class NoiseProvider(Protocol):
+    """Protocol for listing available noise files.
+
+    Consistent with TtsProvider living in tts_stage.py — the protocol belongs
+    alongside the stage that uses it.
+    """
+
+    def list_files(self) -> list[Path]: ...
+
+
+def _read_duration_s(audio_reader: AudioReader, path: Path) -> float:
+    """Read a file and return its duration in seconds.
+
+    Handles both a running event loop (uses a thread executor) and no loop
+    (uses asyncio.run()).
+    """
+    async def _read() -> float:
+        data = await audio_reader.read(path)
+        return len(data.samples) / data.sample_rate
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — safe to call asyncio.run()
+        return asyncio.run(_read())
+
+    # Inside a running loop — run in a thread to avoid blocking the loop
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(asyncio.run, _read())
+        return future.result()
+
+
+class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
+    """Augmentation stage that mixes environmental noise into WAV samples.
+
+    The noise file is always chosen (even when not applied) so that the
+    content hash remains stable across configuration changes. Only
+    noise_start_s and noise_volume are set to 0.0 when the noise is not applied.
+
+    Noise mixing algorithm: slice noise at noise_start_s for len(audio) samples,
+    zero-pad if noise is shorter after the slice, multiply by noise_volume, add to
+    audio samples, then clip to [-1.0, 1.0].
+
+    input_dir is the directory containing the input WAV files referenced by
+    AudioSample.path. This is typically the output directory of the preceding stage.
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        manifest_store: ManifestStore,
+        audio_reader: AudioReader,
+        audio_writer: AudioWriter,
+        input_dir: Path,
+        noise_provider: NoiseProvider,
+        params: AddBackgroundNoiseParams,
+    ) -> None:
+        super().__init__(output_dir, manifest_store)
+        self._audio_reader = audio_reader
+        self._audio_writer = audio_writer
+        self._input_dir = input_dir
+        self._noise_provider = noise_provider
+        self._vary_probability = params.vary_probability
+        self._volume_filter = MinMaxFilter(params.volume_min, params.volume_max, precision=2)
+
+    def _get_applied_values(
+        self, sample: AudioSample, generator: VariationGenerator
+    ) -> dict[str, Any]:
+        # Always choose a noise file for hash stability
+        noise_files = sorted([p.name for p in self._noise_provider.list_files()])
+        noise_file: str = generator.choose("noise_file", noise_files)
+
+        if generator.should_vary("noise", self._vary_probability):
+            # Derive noise_start_s bounds from file durations
+            noise_path = self._noise_provider.list_files()[0].parent / noise_file
+            audio_path = self._input_dir / sample.path
+
+            noise_duration_s = _read_duration_s(self._audio_reader, noise_path)
+            audio_duration_s = _read_duration_s(self._audio_reader, audio_path)
+
+            max_start_s = noise_duration_s - audio_duration_s
+            clamped_max = max(0.0, max_start_s)
+            start_filter = MinMaxFilter(0.0, clamped_max, precision=2)
+            noise_start_s = generator.generate("noise_start_s", start_filter)
+            noise_volume = generator.generate("noise_volume", self._volume_filter)
+        else:
+            noise_start_s = 0.0
+            noise_volume = 0.0
+
+        return {
+            "noise_file": noise_file,
+            "noise_start_s": float(noise_start_s),
+            "noise_volume": float(noise_volume),
+        }
+
+    def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
+        noise_file: str = applied_values["noise_file"]
+        noise_volume: float = applied_values["noise_volume"]
+        noise_filestem = Path(noise_file).stem
+        return f"{input_sample.id}_{noise_filestem}_v{int(noise_volume * 100)}"
+
+    async def _generate_output(
+        self,
+        input_sample: AudioSample,
+        output_id: str,
+        output_seed: int,
+        applied_values: dict[str, Any],
+        parent_content_hash: str,
+    ) -> AudioSample:
+        noise_file: str = applied_values["noise_file"]
+        noise_start_s: float = applied_values["noise_start_s"]
+        noise_volume: float = applied_values["noise_volume"]
+
+        input_path = self._input_dir / input_sample.path
+        audio = await self._audio_reader.read(input_path)
+        output_samples = audio.samples.copy()
+
+        if noise_volume > 0.0:
+            # Resolve noise file path via provider
+            noise_path = self._noise_provider.list_files()[0].parent / noise_file
+            noise_audio = await self._audio_reader.read(noise_path)
+
+            start_sample = int(noise_start_s * noise_audio.sample_rate)
+            n_needed = len(output_samples)
+            noise_slice = noise_audio.samples[start_sample: start_sample + n_needed]
+
+            # Zero-pad if noise slice is shorter than audio
+            if len(noise_slice) < n_needed:
+                noise_slice = np.pad(noise_slice, (0, n_needed - len(noise_slice)))
+
+            output_samples = output_samples + noise_volume * noise_slice
+            output_samples = np.clip(output_samples, -1.0, 1.0).astype(np.float32)
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")
+        await self._audio_writer.write(output_path, AudioData(samples=output_samples, sample_rate=audio.sample_rate))
+
+        content_hash = self._compute_content_hash(
+            parent_content_hash, output_seed, applied_values
+        )
+
+        return AudioSample(
+            id=output_id,
+            seed=output_seed,
+            content_hash=content_hash,
+            path=Path(f"{output_id}.wav"),
+            parent_content_hash=parent_content_hash,
+            transcript=input_sample.transcript,
+            applied_values=applied_values,
+        )

--- a/ml/pipeline/speech/background_noise_stage.py
+++ b/ml/pipeline/speech/background_noise_stage.py
@@ -9,6 +9,14 @@ noise_start_s bounds are derived from file durations: both the noise file and th
 audio sample file are read to compute max_start_s = noise_duration_s - audio_duration_s.
 When the noise file is shorter than the audio sample, max_start_s is negative and
 clamped to 0.0 (min and max both 0.0).
+
+_noise_dir is stored directly in the constructor and used to resolve noise file
+paths, eliminating redundant list_files() calls and the IndexError risk from an
+empty noise directory.
+
+_read_duration_s runs the async read in a thread executor when called from a running
+event loop, using the lambda form (executor.submit(lambda: asyncio.run(...))) to avoid
+passing a pre-created coroutine to asyncio.run in another thread.
 """
 
 from __future__ import annotations
@@ -42,22 +50,29 @@ class NoiseProvider(Protocol):
 def _read_duration_s(audio_reader: AudioReader, path: Path) -> float:
     """Read a file and return its duration in seconds.
 
-    Handles both a running event loop (uses a thread executor) and no loop
-    (uses asyncio.run()).
+    When called outside a running event loop, uses asyncio.run() directly.
+    When called from within a running event loop (e.g. from a synchronous
+    method invoked by an async caller), runs asyncio.run() in a thread executor
+    so the loop thread is not blocked. Uses the lambda form
+    (executor.submit(lambda: asyncio.run(_read()))) to create the coroutine
+    inside the worker thread, avoiding passing a pre-created coroutine across
+    threads.
     """
     async def _read() -> float:
         data = await audio_reader.read(path)
         return len(data.samples) / data.sample_rate
 
     try:
-        loop = asyncio.get_running_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
-        # No running loop — safe to call asyncio.run()
+        # No running loop — safe to call asyncio.run() directly
         return asyncio.run(_read())
 
-    # Inside a running loop — run in a thread to avoid blocking the loop
+    # Inside a running loop — run in a thread to avoid blocking the loop.
+    # The lambda creates the coroutine inside the worker thread so a fresh
+    # event loop is used per asyncio.run() call.
     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(asyncio.run, _read())
+        future = executor.submit(lambda: asyncio.run(_read()))
         return future.result()
 
 
@@ -74,6 +89,10 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
 
     input_dir is the directory containing the input WAV files referenced by
     AudioSample.path. This is typically the output directory of the preceding stage.
+
+    noise_dir is the directory containing noise WAV files. Stored directly rather
+    than derived from NoiseProvider.list_files()[0].parent to avoid redundant
+    filesystem calls and IndexError on an empty directory.
     """
 
     def __init__(
@@ -83,6 +102,7 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         audio_reader: AudioReader,
         audio_writer: AudioWriter,
         input_dir: Path,
+        noise_dir: Path,
         noise_provider: NoiseProvider,
         params: AddBackgroundNoiseParams,
     ) -> None:
@@ -90,6 +110,7 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         self._audio_reader = audio_reader
         self._audio_writer = audio_writer
         self._input_dir = input_dir
+        self._noise_dir = noise_dir
         self._noise_provider = noise_provider
         self._vary_probability = params.vary_probability
         self._volume_filter = MinMaxFilter(params.volume_min, params.volume_max, precision=2)
@@ -97,13 +118,17 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     def _get_applied_values(
         self, sample: AudioSample, generator: VariationGenerator
     ) -> dict[str, Any]:
-        # Always choose a noise file for hash stability
+        # Always choose a noise file for hash stability.
+        # list_files() is called once; _noise_dir resolves the full path.
         noise_files = sorted([p.name for p in self._noise_provider.list_files()])
         noise_file: str = generator.choose("noise_file", noise_files)
 
         if generator.should_vary("noise", self._vary_probability):
-            # Derive noise_start_s bounds from file durations
-            noise_path = self._noise_provider.list_files()[0].parent / noise_file
+            # noise_start_s bounds are derived from file durations. Both files are read
+            # synchronously here because _get_applied_values is a synchronous method.
+            # The durations are needed to clamp the start so the noise slice contains
+            # actual noise data rather than silence from an out-of-range offset.
+            noise_path = self._noise_dir / noise_file
             audio_path = self._input_dir / sample.path
 
             noise_duration_s = _read_duration_s(self._audio_reader, noise_path)
@@ -147,8 +172,7 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
         output_samples = audio.samples.copy()
 
         if noise_volume > 0.0:
-            # Resolve noise file path via provider
-            noise_path = self._noise_provider.list_files()[0].parent / noise_file
+            noise_path = self._noise_dir / noise_file
             noise_audio = await self._audio_reader.read(noise_path)
 
             start_sample = int(noise_start_s * noise_audio.sample_rate)

--- a/ml/pipeline/speech/background_noise_stage.py
+++ b/ml/pipeline/speech/background_noise_stage.py
@@ -1,28 +1,7 @@
-"""BackgroundNoiseAugmentor: mix environmental noise into WAV audio samples.
-
-noise_file is always chosen (choose() always called) for hash stability, even when
-not applied. noise_start_s and noise_volume are stored as 0.0 when should_vary
-returns False. All three keys (noise_file, noise_start_s, noise_volume) are always
-present in every applied_values dict.
-
-noise_start_s bounds are derived from file durations: both the noise file and the
-audio sample file are read to compute max_start_s = noise_duration_s - audio_duration_s.
-When the noise file is shorter than the audio sample, max_start_s is negative and
-clamped to 0.0 (min and max both 0.0).
-
-_noise_dir is stored directly in the constructor and used to resolve noise file
-paths, eliminating redundant list_files() calls and the IndexError risk from an
-empty noise directory.
-
-_read_duration_s runs the async read in a thread executor when called from a running
-event loop, using the lambda form (executor.submit(lambda: asyncio.run(...))) to avoid
-passing a pre-created coroutine to asyncio.run in another thread.
-"""
+"""BackgroundNoiseAugmentor: mix environmental noise into WAV audio samples."""
 
 from __future__ import annotations
 
-import asyncio
-import concurrent.futures
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -47,52 +26,16 @@ class NoiseProvider(Protocol):
     def list_files(self) -> list[Path]: ...
 
 
-def _read_duration_s(audio_reader: AudioReader, path: Path) -> float:
-    """Read a file and return its duration in seconds.
-
-    When called outside a running event loop, uses asyncio.run() directly.
-    When called from within a running event loop (e.g. from a synchronous
-    method invoked by an async caller), runs asyncio.run() in a thread executor
-    so the loop thread is not blocked. Uses the lambda form
-    (executor.submit(lambda: asyncio.run(_read()))) to create the coroutine
-    inside the worker thread, avoiding passing a pre-created coroutine across
-    threads.
-    """
-    async def _read() -> float:
-        data = await audio_reader.read(path)
-        return len(data.samples) / data.sample_rate
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        # No running loop — safe to call asyncio.run() directly
-        return asyncio.run(_read())
-
-    # Inside a running loop — run in a thread to avoid blocking the loop.
-    # The lambda creates the coroutine inside the worker thread so a fresh
-    # event loop is used per asyncio.run() call.
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(lambda: asyncio.run(_read()))
-        return future.result()
-
-
 class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     """Augmentation stage that mixes environmental noise into WAV samples.
 
     The noise file is always chosen (even when not applied) so that the
     content hash remains stable across configuration changes. Only
-    noise_start_s and noise_volume are set to 0.0 when the noise is not applied.
+    noise_volume is set to 0.0 when the noise is not applied. noise_start_s
+    is always 0.0 (noise always mixed from the start of the noise file).
 
-    Noise mixing algorithm: slice noise at noise_start_s for len(audio) samples,
-    zero-pad if noise is shorter after the slice, multiply by noise_volume, add to
-    audio samples, then clip to [-1.0, 1.0].
-
-    input_dir is the directory containing the input WAV files referenced by
-    AudioSample.path. This is typically the output directory of the preceding stage.
-
-    noise_dir is the directory containing noise WAV files. Stored directly rather
-    than derived from NoiseProvider.list_files()[0].parent to avoid redundant
-    filesystem calls and IndexError on an empty directory.
+    Noise mixing: slice noise at noise_start_s for len(audio) samples,
+    zero-pad if noise is shorter, multiply by noise_volume, add, clip to [-1.0, 1.0].
     """
 
     def __init__(
@@ -118,34 +61,19 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     def _get_applied_values(
         self, sample: AudioSample, generator: VariationGenerator
     ) -> dict[str, Any]:
-        # Always choose a noise file for hash stability.
+        # Always choose a noise file for hash stability, even when not applied.
         # list_files() is called once; _noise_dir resolves the full path.
         noise_files = sorted([p.name for p in self._noise_provider.list_files()])
         noise_file: str = generator.choose("noise_file", noise_files)
 
         if generator.should_vary("noise", self._vary_probability):
-            # noise_start_s bounds are derived from file durations. Both files are read
-            # synchronously here because _get_applied_values is a synchronous method.
-            # The durations are needed to clamp the start so the noise slice contains
-            # actual noise data rather than silence from an out-of-range offset.
-            noise_path = self._noise_dir / noise_file
-            audio_path = self._input_dir / sample.path
-
-            noise_duration_s = _read_duration_s(self._audio_reader, noise_path)
-            audio_duration_s = _read_duration_s(self._audio_reader, audio_path)
-
-            max_start_s = noise_duration_s - audio_duration_s
-            clamped_max = max(0.0, max_start_s)
-            start_filter = MinMaxFilter(0.0, clamped_max, precision=2)
-            noise_start_s = generator.generate("noise_start_s", start_filter)
             noise_volume = generator.generate("noise_volume", self._volume_filter)
         else:
-            noise_start_s = 0.0
             noise_volume = 0.0
 
         return {
             "noise_file": noise_file,
-            "noise_start_s": float(noise_start_s),
+            "noise_start_s": 0.0,  # Always zero — noise is mixed from the start of the file.
             "noise_volume": float(noise_volume),
         }
 
@@ -169,22 +97,24 @@ class BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
 
         input_path = self._input_dir / input_sample.path
         audio = await self._audio_reader.read(input_path)
-        output_samples = audio.samples.copy()
 
         if noise_volume > 0.0:
             noise_path = self._noise_dir / noise_file
             noise_audio = await self._audio_reader.read(noise_path)
 
             start_sample = int(noise_start_s * noise_audio.sample_rate)
-            n_needed = len(output_samples)
+            n_needed = len(audio.samples)
             noise_slice = noise_audio.samples[start_sample: start_sample + n_needed]
 
             # Zero-pad if noise slice is shorter than audio
             if len(noise_slice) < n_needed:
                 noise_slice = np.pad(noise_slice, (0, n_needed - len(noise_slice)))
 
-            output_samples = output_samples + noise_volume * noise_slice
-            output_samples = np.clip(output_samples, -1.0, 1.0).astype(np.float32)
+            output_samples: np.ndarray = np.clip(
+                audio.samples + noise_volume * noise_slice, -1.0, 1.0
+            ).astype(np.float32)
+        else:
+            output_samples = audio.samples
 
         self._output_dir.mkdir(parents=True, exist_ok=True)
         output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")

--- a/ml/pipeline/speech/mic_noise_stage.py
+++ b/ml/pipeline/speech/mic_noise_stage.py
@@ -74,12 +74,13 @@ class MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
 
         input_path = self._input_dir / input_sample.path
         audio = await self._audio_reader.read(input_path)
-        output_samples = audio.samples.copy()
 
         if amplitude > 0.0:
             rng = np.random.default_rng(output_seed)
-            noise = rng.normal(0, amplitude, len(output_samples)).astype(np.float32)
-            output_samples = np.clip(output_samples + noise, -1.0, 1.0).astype(np.float32)
+            noise = rng.normal(0, amplitude, len(audio.samples)).astype(np.float32)
+            output_samples: np.ndarray = np.clip(audio.samples + noise, -1.0, 1.0).astype(np.float32)
+        else:
+            output_samples = audio.samples
 
         self._output_dir.mkdir(parents=True, exist_ok=True)
         output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")

--- a/ml/pipeline/speech/mic_noise_stage.py
+++ b/ml/pipeline/speech/mic_noise_stage.py
@@ -1,0 +1,100 @@
+"""MicrophoneNoiseAugmentor: add Gaussian microphone noise to WAV audio samples.
+
+mic_noise_amplitude is stored as 0.0 when should_vary returns False.
+Gaussian noise is seeded from output_seed for reproducibility.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.core.modifier_stage import ModifierStage
+from pipeline.core.randomization import MinMaxFilter, VariationGenerator
+from pipeline.core.sample import AudioSample
+from pipeline.io.audio_io import AudioData, AudioReader, AudioWriter
+from pipeline.stages import conventions
+from pipeline.stages.params import AddMicNoiseParams
+
+
+class MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
+    """Augmentation stage that adds Gaussian microphone noise to WAV samples.
+
+    mic_noise_amplitude is stored as 0.0 when the noise is not applied. Gaussian
+    noise uses output_seed for reproducibility via numpy's default_rng.
+
+    input_dir is the directory containing the input WAV files referenced by
+    AudioSample.path. This is typically the output directory of the preceding stage.
+    """
+
+    def __init__(
+        self,
+        output_dir: Path,
+        manifest_store: ManifestStore,
+        audio_reader: AudioReader,
+        audio_writer: AudioWriter,
+        input_dir: Path,
+        params: AddMicNoiseParams,
+    ) -> None:
+        super().__init__(output_dir, manifest_store)
+        self._audio_reader = audio_reader
+        self._audio_writer = audio_writer
+        self._input_dir = input_dir
+        self._vary_probability = params.vary_probability
+        self._amplitude_filter = MinMaxFilter(params.amplitude_min, params.amplitude_max, precision=3)
+
+    def _get_applied_values(
+        self, sample: AudioSample, generator: VariationGenerator
+    ) -> dict[str, Any]:
+        if generator.should_vary("mic_noise_amplitude", self._vary_probability):
+            amplitude = generator.generate("mic_noise_amplitude", self._amplitude_filter)
+        else:
+            amplitude = 0.0
+
+        return {
+            "mic_noise_amplitude": float(amplitude),
+        }
+
+    def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
+        amplitude: float = applied_values["mic_noise_amplitude"]
+        return f"{input_sample.id}_mic{int(amplitude * 1000)}"
+
+    async def _generate_output(
+        self,
+        input_sample: AudioSample,
+        output_id: str,
+        output_seed: int,
+        applied_values: dict[str, Any],
+        parent_content_hash: str,
+    ) -> AudioSample:
+        amplitude: float = applied_values["mic_noise_amplitude"]
+
+        input_path = self._input_dir / input_sample.path
+        audio = await self._audio_reader.read(input_path)
+        output_samples = audio.samples.copy()
+
+        if amplitude > 0.0:
+            rng = np.random.default_rng(output_seed)
+            noise = rng.normal(0, amplitude, len(output_samples)).astype(np.float32)
+            output_samples = np.clip(output_samples + noise, -1.0, 1.0).astype(np.float32)
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")
+        await self._audio_writer.write(output_path, AudioData(samples=output_samples, sample_rate=audio.sample_rate))
+
+        content_hash = self._compute_content_hash(
+            parent_content_hash, output_seed, applied_values
+        )
+
+        return AudioSample(
+            id=output_id,
+            seed=output_seed,
+            content_hash=content_hash,
+            path=Path(f"{output_id}.wav"),
+            parent_content_hash=parent_content_hash,
+            transcript=input_sample.transcript,
+            applied_values=applied_values,
+        )

--- a/ml/pipeline/speech/mic_noise_stage.py
+++ b/ml/pipeline/speech/mic_noise_stage.py
@@ -1,6 +1,7 @@
 """MicrophoneNoiseAugmentor: add Gaussian microphone noise to WAV audio samples.
 
 mic_noise_amplitude is stored as 0.0 when should_vary returns False.
+When amplitude == 0.0, the input sample is returned unchanged — no file is written.
 Gaussian noise is seeded from output_seed for reproducibility.
 """
 
@@ -23,8 +24,11 @@ from pipeline.stages.params import AddMicNoiseParams
 class MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     """Augmentation stage that adds Gaussian microphone noise to WAV samples.
 
-    mic_noise_amplitude is stored as 0.0 when the noise is not applied. Gaussian
-    noise uses output_seed for reproducibility via numpy's default_rng.
+    mic_noise_amplitude is stored as 0.0 when the noise is not applied. When
+    amplitude == 0.0, the input sample is returned unchanged — no file is
+    written and no I/O occurs.
+
+    Gaussian noise uses output_seed for reproducibility via numpy's default_rng.
 
     input_dir is the directory containing the input WAV files referenced by
     AudioSample.path. This is typically the output directory of the preceding stage.
@@ -60,6 +64,9 @@ class MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
 
     def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
         amplitude: float = applied_values["mic_noise_amplitude"]
+        if amplitude == 0.0:
+            # No modification — return the input id unchanged.
+            return input_sample.id
         return f"{input_sample.id}_mic{int(amplitude * 1000)}"
 
     async def _generate_output(
@@ -72,15 +79,16 @@ class MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample]):
     ) -> AudioSample:
         amplitude: float = applied_values["mic_noise_amplitude"]
 
+        # When not applied, return the input sample unchanged — no I/O.
+        if amplitude == 0.0:
+            return input_sample
+
         input_path = self._input_dir / input_sample.path
         audio = await self._audio_reader.read(input_path)
 
-        if amplitude > 0.0:
-            rng = np.random.default_rng(output_seed)
-            noise = rng.normal(0, amplitude, len(audio.samples)).astype(np.float32)
-            output_samples: np.ndarray = np.clip(audio.samples + noise, -1.0, 1.0).astype(np.float32)
-        else:
-            output_samples = audio.samples
+        rng = np.random.default_rng(output_seed)
+        noise = rng.normal(0, amplitude, len(audio.samples)).astype(np.float32)
+        output_samples: np.ndarray = np.clip(audio.samples + noise, -1.0, 1.0).astype(np.float32)
 
         self._output_dir.mkdir(parents=True, exist_ok=True)
         output_path = conventions.sample_file_path(self._output_dir, output_id, "wav")

--- a/ml/pipeline/stages/params.py
+++ b/ml/pipeline/stages/params.py
@@ -55,6 +55,7 @@ class AddMicNoiseParams:
 class PipelineParams:
     variations_per_phrase: int
     subsample_rate: int
+    sample_rate: int
     generate_phrases: GeneratePhraseParams
     generate_samples: GenerateSamplesParams
     add_delays: AddDelaysParams
@@ -76,6 +77,7 @@ class PipelineParams:
         return cls(
             variations_per_phrase=int(pipeline["variations_per_phrase"]),
             subsample_rate=int(pipeline["subsample_rate"]),
+            sample_rate=int(pipeline["sample_rate"]),
             generate_phrases=GeneratePhraseParams(
                 repeat_modifier_chance=float(stage_phrases["repeat_modifier_chance"]),
                 pleasantry_chance=float(stage_phrases["pleasantry_chance"]),

--- a/ml/pipeline/stages/params.py
+++ b/ml/pipeline/stages/params.py
@@ -38,12 +38,28 @@ class AddDelaysParams:
 
 
 @dataclass
+class AddBackgroundNoiseParams:
+    vary_probability: float
+    volume_min: float
+    volume_max: float
+
+
+@dataclass
+class AddMicNoiseParams:
+    vary_probability: float
+    amplitude_min: float
+    amplitude_max: float
+
+
+@dataclass
 class PipelineParams:
     variations_per_phrase: int
     subsample_rate: int
     generate_phrases: GeneratePhraseParams
     generate_samples: GenerateSamplesParams
     add_delays: AddDelaysParams
+    add_background_noise: AddBackgroundNoiseParams
+    add_mic_noise: AddMicNoiseParams
 
     @classmethod
     def load(cls, path: Path) -> "PipelineParams":
@@ -54,6 +70,8 @@ class PipelineParams:
         stage_phrases = raw["stages"]["generate_phrases"]
         stage_samples = raw["stages"]["generate_speech_samples"]
         stage_delays = raw["stages"]["add_delays"]
+        stage_bg_noise = raw["stages"]["add_background_noise"]
+        stage_mic_noise = raw["stages"]["add_mic_noise"]
 
         return cls(
             variations_per_phrase=int(pipeline["variations_per_phrase"]),
@@ -76,5 +94,15 @@ class PipelineParams:
                 suffix_vary_probability=float(stage_delays["suffix_vary_probability"]),
                 suffix_min_s=float(stage_delays["suffix_min_s"]),
                 suffix_max_s=float(stage_delays["suffix_max_s"]),
+            ),
+            add_background_noise=AddBackgroundNoiseParams(
+                vary_probability=float(stage_bg_noise["vary_probability"]),
+                volume_min=float(stage_bg_noise["volume_min"]),
+                volume_max=float(stage_bg_noise["volume_max"]),
+            ),
+            add_mic_noise=AddMicNoiseParams(
+                vary_probability=float(stage_mic_noise["vary_probability"]),
+                amplitude_min=float(stage_mic_noise["amplitude_min"]),
+                amplitude_max=float(stage_mic_noise["amplitude_max"]),
             ),
         )

--- a/ml/pipeline/stages/speech_05_add_background_noise.py
+++ b/ml/pipeline/stages/speech_05_add_background_noise.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.io.audio_io import LibrosaAudioReader, SoundfileAudioWriter
+from pipeline.speech.background_noise_stage import BackgroundNoiseAugmentor
+from pipeline.stages import conventions
+from pipeline.stages.params import PipelineParams
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+class _DirectoryNoiseProvider:
+    """NoiseProvider backed by a filesystem directory.
+
+    Lists all WAV files in the given directory. DVC wiring points this at the
+    appropriate data/ path; this class requires no knowledge of the DVC layout.
+    """
+
+    def __init__(self, noise_dir: Path) -> None:
+        self._noise_dir = noise_dir
+
+    def list_files(self) -> list[Path]:
+        return list(self._noise_dir.glob("*.wav"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Add environmental background noise to WAV audio samples"
+    )
+    parser.add_argument("--input-manifest-dir", required=True, type=Path)
+    parser.add_argument("--noise-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    params = PipelineParams.load(conventions.params_path(_PROJECT_ROOT))
+
+    store = ManifestStore()
+    input_manifest = store.read(conventions.manifest_path(args.input_manifest_dir))
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    stage = BackgroundNoiseAugmentor(
+        output_dir=args.output_dir,
+        manifest_store=store,
+        audio_reader=LibrosaAudioReader(),
+        audio_writer=SoundfileAudioWriter(),
+        input_dir=args.input_manifest_dir,
+        noise_provider=_DirectoryNoiseProvider(args.noise_dir),
+        params=params.add_background_noise,
+    )
+
+    asyncio.run(
+        stage.transform(
+            input_manifest,
+            conventions.manifest_path(args.output_dir),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/pipeline/stages/speech_05_add_background_noise.py
+++ b/ml/pipeline/stages/speech_05_add_background_noise.py
@@ -8,7 +8,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from pipeline.core.manifest import ManifestStore
-from pipeline.io.audio_io import LibrosaAudioReader, SoundfileAudioWriter
+from pipeline.io.audio_io import AudioData, LibrosaAudioReader, SoundfileAudioWriter
 from pipeline.speech.background_noise_stage import BackgroundNoiseAugmentor
 from pipeline.stages import conventions
 from pipeline.stages.params import PipelineParams
@@ -19,23 +19,36 @@ _PROJECT_ROOT = Path(__file__).parents[2]
 class _DirectoryNoiseProvider:
     """NoiseProvider backed by a filesystem directory.
 
-    Lists all WAV files in the given directory. DVC wiring points this at the
-    appropriate data/ path; this class requires no knowledge of the DVC layout.
+    Loads all WAV files in the given directory at construction time, resampling
+    them to ``sample_rate`` so that all noise audio matches the pipeline sample
+    rate. This avoids per-sample I/O at augmentation time and ensures noise
+    files are at the correct sample rate before mixing.
 
     Raises ValueError with the directory path if the directory contains no WAV
-    files, so that a misconfigured --noise-dir produces an actionable error
-    rather than the opaque ValueError("options must be non-empty") from
-    VariationGenerator.choose().
+    files, so that a misconfigured --noise-dir produces an actionable error.
     """
 
-    def __init__(self, noise_dir: Path) -> None:
+    def __init__(self, noise_dir: Path, sample_rate: int) -> None:
         self._noise_dir = noise_dir
+        self._items: list[tuple[str, AudioData]] = self._load(noise_dir, sample_rate)
 
-    def list_files(self) -> list[Path]:
-        files = list(self._noise_dir.glob("*.wav"))
-        if not files:
-            raise ValueError(f"No WAV files found in noise directory: {self._noise_dir}")
-        return files
+    @staticmethod
+    def _load(noise_dir: Path, sample_rate: int) -> list[tuple[str, AudioData]]:
+        import librosa
+
+        wav_paths = sorted(noise_dir.glob("*.wav"))
+        if not wav_paths:
+            raise ValueError(f"No WAV files found in noise directory: {noise_dir}")
+
+        items: list[tuple[str, AudioData]] = []
+        for path in wav_paths:
+            # librosa.load with sr=sample_rate resamples on load if needed.
+            samples, sr = librosa.load(str(path), sr=sample_rate, mono=True, dtype="float32")
+            items.append((path.name, AudioData(samples=samples, sample_rate=int(sr))))
+        return items
+
+    def list_files(self) -> list[tuple[str, AudioData]]:
+        return list(self._items)
 
 
 def main() -> None:
@@ -60,8 +73,7 @@ def main() -> None:
         audio_reader=LibrosaAudioReader(),
         audio_writer=SoundfileAudioWriter(),
         input_dir=args.input_manifest_dir,
-        noise_dir=args.noise_dir,
-        noise_provider=_DirectoryNoiseProvider(args.noise_dir),
+        noise_provider=_DirectoryNoiseProvider(args.noise_dir, params.sample_rate),
         params=params.add_background_noise,
     )
 

--- a/ml/pipeline/stages/speech_05_add_background_noise.py
+++ b/ml/pipeline/stages/speech_05_add_background_noise.py
@@ -21,13 +21,21 @@ class _DirectoryNoiseProvider:
 
     Lists all WAV files in the given directory. DVC wiring points this at the
     appropriate data/ path; this class requires no knowledge of the DVC layout.
+
+    Raises ValueError with the directory path if the directory contains no WAV
+    files, so that a misconfigured --noise-dir produces an actionable error
+    rather than the opaque ValueError("options must be non-empty") from
+    VariationGenerator.choose().
     """
 
     def __init__(self, noise_dir: Path) -> None:
         self._noise_dir = noise_dir
 
     def list_files(self) -> list[Path]:
-        return list(self._noise_dir.glob("*.wav"))
+        files = list(self._noise_dir.glob("*.wav"))
+        if not files:
+            raise ValueError(f"No WAV files found in noise directory: {self._noise_dir}")
+        return files
 
 
 def main() -> None:
@@ -52,6 +60,7 @@ def main() -> None:
         audio_reader=LibrosaAudioReader(),
         audio_writer=SoundfileAudioWriter(),
         input_dir=args.input_manifest_dir,
+        noise_dir=args.noise_dir,
         noise_provider=_DirectoryNoiseProvider(args.noise_dir),
         params=params.add_background_noise,
     )

--- a/ml/pipeline/stages/speech_06_add_mic_noise.py
+++ b/ml/pipeline/stages/speech_06_add_mic_noise.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.io.audio_io import LibrosaAudioReader, SoundfileAudioWriter
+from pipeline.speech.mic_noise_stage import MicrophoneNoiseAugmentor
+from pipeline.stages import conventions
+from pipeline.stages.params import PipelineParams
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Add Gaussian microphone noise to WAV audio samples"
+    )
+    parser.add_argument("--input-manifest-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    params = PipelineParams.load(conventions.params_path(_PROJECT_ROOT))
+
+    store = ManifestStore()
+    input_manifest = store.read(conventions.manifest_path(args.input_manifest_dir))
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    stage = MicrophoneNoiseAugmentor(
+        output_dir=args.output_dir,
+        manifest_store=store,
+        audio_reader=LibrosaAudioReader(),
+        audio_writer=SoundfileAudioWriter(),
+        input_dir=args.input_manifest_dir,
+        params=params.add_mic_noise,
+    )
+
+    asyncio.run(
+        stage.transform(
+            input_manifest,
+            conventions.manifest_path(args.output_dir),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/test/pipeline/speech/test_background_noise_stage.py
+++ b/ml/test/pipeline/speech/test_background_noise_stage.py
@@ -52,30 +52,20 @@ def _make_audio_sample(
 
 
 class _RecordingAudioReader:
-    """Stub AudioReader that returns configured durations per path."""
+    """Stub AudioReader that records read() calls and returns silence."""
 
     def __init__(
         self,
         sample_rate: int = 16000,
         audio_duration_s: float = 0.5,
-        noise_duration_s: float = 2.0,
     ) -> None:
         self.calls: list[Path] = []
         self._sample_rate = sample_rate
         self._audio_duration_s = audio_duration_s
-        self._noise_duration_s = noise_duration_s
-        # If path stem ends with "noise", return noise duration, else audio duration
-        self._noise_paths: set[Path] = set()
-
-    def register_noise_path(self, path: Path) -> None:
-        self._noise_paths.add(path)
 
     async def read(self, path: Path) -> AudioData:
         self.calls.append(path)
-        if path in self._noise_paths or path.parent.name == "noise":
-            n_samples = int(self._sample_rate * self._noise_duration_s)
-        else:
-            n_samples = int(self._sample_rate * self._audio_duration_s)
+        n_samples = int(self._sample_rate * self._audio_duration_s)
         samples = np.zeros(n_samples, dtype=np.float32)
         return AudioData(samples=samples, sample_rate=self._sample_rate)
 
@@ -92,14 +82,27 @@ class _RecordingAudioWriter:
 
 
 class _FakeNoiseProvider:
-    """Fake NoiseProvider that returns a fixed list of noise file paths."""
+    """Fake NoiseProvider that returns a fixed list of (name, AudioData) tuples."""
 
-    def __init__(self, noise_dir: Path, filenames: list[str]) -> None:
-        self._noise_dir = noise_dir
-        self._filenames = filenames
+    def __init__(
+        self,
+        filenames: list[str],
+        sample_rate: int = 16000,
+        duration_s: float = 2.0,
+    ) -> None:
+        self._items = [
+            (
+                name,
+                AudioData(
+                    samples=(np.random.default_rng(i).random(int(sample_rate * duration_s)) * 2 - 1).astype(np.float32),
+                    sample_rate=sample_rate,
+                ),
+            )
+            for i, name in enumerate(filenames)
+        ]
 
-    def list_files(self) -> list[Path]:
-        return [self._noise_dir / name for name in self._filenames]
+    def list_files(self) -> list[tuple[str, AudioData]]:
+        return list(self._items)
 
 
 def _make_params(
@@ -116,7 +119,6 @@ def _make_params(
 
 def _make_stage(
     output_dir: Path,
-    noise_dir: Path | None = None,
     *,
     audio_reader: _RecordingAudioReader | None = None,
     audio_writer: _RecordingAudioWriter | None = None,
@@ -127,16 +129,14 @@ def _make_stage(
     volume_min: float = 0.0,
     volume_max: float = 0.3,
     noise_filenames: list[str] | None = None,
+    sample_rate: int = 16000,
 ) -> tuple[BackgroundNoiseAugmentor, _RecordingAudioReader, _RecordingAudioWriter]:
     if audio_reader is None:
-        audio_reader = _RecordingAudioReader()
+        audio_reader = _RecordingAudioReader(sample_rate=sample_rate)
     if audio_writer is None:
         audio_writer = _RecordingAudioWriter()
     if input_dir is None:
         input_dir = output_dir
-    if noise_dir is None:
-        noise_dir = output_dir / "noise"
-        noise_dir.mkdir(parents=True, exist_ok=True)
     if params is None:
         params = _make_params(
             vary_probability=vary_probability,
@@ -146,25 +146,24 @@ def _make_stage(
     if noise_provider is None:
         if noise_filenames is None:
             noise_filenames = ["traffic.wav"]
-        noise_provider = _FakeNoiseProvider(noise_dir, noise_filenames)
+        noise_provider = _FakeNoiseProvider(noise_filenames, sample_rate=sample_rate)
     stage = BackgroundNoiseAugmentor(
         output_dir=output_dir,
         manifest_store=ManifestStore(),
         audio_reader=audio_reader,
         audio_writer=audio_writer,
         input_dir=input_dir,
-        noise_dir=noise_dir,
         noise_provider=noise_provider,
         params=params,
     )
     return stage, audio_reader, audio_writer
 
 
-def _write_noise_wav(noise_dir: Path, filename: str, sample_rate: int = 16000, duration_s: float = 2.0) -> Path:
-    noise_dir.mkdir(parents=True, exist_ok=True)
-    path = noise_dir / filename
+def _write_audio_wav(dir: Path, filename: str, sample_rate: int = 16000, duration_s: float = 0.5) -> Path:
+    dir.mkdir(parents=True, exist_ok=True)
+    path = dir / filename
     n_samples = int(sample_rate * duration_s)
-    data = (np.random.default_rng(42).random(n_samples) * 2 - 1).astype(np.float32)
+    data = np.zeros(n_samples, dtype=np.float32)
     sf.write(str(path), data, sample_rate, format="WAV", subtype="PCM_16")
     return path
 
@@ -331,17 +330,42 @@ class TestDeriveId:
 
 
 class TestGenerateOutput:
-    def test_generate_output_calls_audio_reader_for_input_and_noise(self, tmp_path: Path) -> None:
-        """When noise is applied (vary_probability=1.0), reader is called for both audio and noise."""
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav")
-
-        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+    def test_generate_output_does_not_call_reader_when_volume_is_zero(self, tmp_path: Path) -> None:
+        """When noise not applied (volume=0), no audio reading occurs."""
+        reader = _RecordingAudioReader()
         stage, _, _ = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
+            audio_reader=reader,
+            vary_probability=0.0,
+        )
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 0
+
+    def test_generate_output_does_not_call_writer_when_volume_is_zero(self, tmp_path: Path) -> None:
+        """When noise not applied (volume=0), no file is written."""
+        stage, _, writer = _make_stage(
+            tmp_path,
+            vary_probability=0.0,
+        )
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == 0
+
+    def test_generate_output_returns_input_when_volume_is_zero(self, tmp_path: Path) -> None:
+        """When noise not applied, transform returns the original input sample."""
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].id == sample.id
+        assert result.samples[0].path == sample.path
+
+    def test_generate_output_calls_audio_reader_for_input_and_does_not_call_for_noise(self, tmp_path: Path) -> None:
+        """When noise is applied (vary_probability=1.0), reader is called for input only; noise comes from provider."""
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav")
+        reader = _RecordingAudioReader()
+        stage, _, _ = _make_stage(
+            tmp_path,
             audio_reader=reader,
             vary_probability=1.0,
             volume_min=0.1,
@@ -350,20 +374,16 @@ class TestGenerateOutput:
         )
         sample = _make_audio_sample(wav_dir=tmp_path)
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
-        # _generate_output reads the input audio file and the noise file — 2 calls total.
-        assert len(reader.calls) >= 2
+        # Only 1 call: the input audio file. Noise audio comes from the provider directly.
+        assert len(reader.calls) == 1
 
-    def test_generate_output_calls_audio_writer(self, tmp_path: Path) -> None:
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav")
-
-        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+    def test_generate_output_calls_audio_writer_when_noise_applied(self, tmp_path: Path) -> None:
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav")
         stage, _, writer = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
-            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
             noise_filenames=["traffic.wav"],
         )
         sample = _make_audio_sample(wav_dir=tmp_path)
@@ -374,73 +394,30 @@ class TestGenerateOutput:
         """Background noise does not change the length of the audio."""
         sample_rate = 16000
         duration_s = 0.5
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav", sample_rate=sample_rate, duration_s=2.0)
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav", sample_rate=sample_rate, duration_s=duration_s)
 
-        reader = _RecordingAudioReader(
-            sample_rate=sample_rate, audio_duration_s=duration_s, noise_duration_s=2.0
-        )
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+        reader = _RecordingAudioReader(sample_rate=sample_rate, audio_duration_s=duration_s)
         stage, _, writer = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
             audio_reader=reader,
             vary_probability=1.0,
             volume_min=0.1,
             volume_max=0.1,
             noise_filenames=["traffic.wav"],
+            sample_rate=sample_rate,
         )
         sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         _path, written_audio = writer.calls[0]
         assert len(written_audio.samples) == int(sample_rate * duration_s)
 
-    def test_output_audio_unchanged_when_volume_is_zero(self, tmp_path: Path) -> None:
-        """When noise not applied (volume=0), output samples equal input samples."""
-        sample_rate = 16000
-        duration_s = 0.1
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav", sample_rate=sample_rate, duration_s=2.0)
-
-        # Use a special reader that returns a known nonzero signal for audio
-        class _ConstantReader:
-            async def read(self, path: Path) -> AudioData:
-                n = int(sample_rate * duration_s)
-                if path.parent.name == "noise":
-                    samples = np.ones(int(sample_rate * 2.0), dtype=np.float32) * 0.9
-                else:
-                    samples = np.full(n, 0.5, dtype=np.float32)
-                return AudioData(samples=samples, sample_rate=sample_rate)
-
-        writer = _RecordingAudioWriter()
-        stage = BackgroundNoiseAugmentor(
-            output_dir=tmp_path,
-            manifest_store=ManifestStore(),
-            audio_reader=_ConstantReader(),
-            audio_writer=writer,
-            input_dir=tmp_path,
-            noise_dir=noise_dir,
-            noise_provider=_FakeNoiseProvider(noise_dir, ["traffic.wav"]),
-            params=_make_params(vary_probability=0.0),
-        )
-        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
-        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
-        _path, written_audio = writer.calls[0]
-        # All samples should still be 0.5 (unchanged)
-        assert np.allclose(written_audio.samples, 0.5)
-
-    def test_transcript_preserved_in_output_sample(self, tmp_path: Path) -> None:
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav")
-
-        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+    def test_transcript_preserved_in_output_sample_when_noise_applied(self, tmp_path: Path) -> None:
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav")
         stage, _, _ = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
-            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
             noise_filenames=["traffic.wav"],
         )
         sample = _make_audio_sample(transcript="VOLUME_UP", wav_dir=tmp_path)
@@ -448,6 +425,35 @@ class TestGenerateOutput:
             stage.transform(Manifest([sample]), tmp_path / "manifest.json")
         )
         assert result.samples[0].transcript == "VOLUME_UP"
+
+    def test_transcript_preserved_in_output_sample_when_not_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample(transcript="CHANNEL_DOWN")
+        result = asyncio.run(
+            stage.transform(Manifest([sample]), tmp_path / "manifest.json")
+        )
+        assert result.samples[0].transcript == "CHANNEL_DOWN"
+
+    def test_sample_rate_mismatch_raises(self, tmp_path: Path) -> None:
+        """Raises ValueError when noise audio has a different sample rate than input audio."""
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav", sample_rate=16000)
+        # Provide noise at a different sample rate
+        noise_provider = _FakeNoiseProvider(["traffic.wav"], sample_rate=8000)
+        reader = _RecordingAudioReader(sample_rate=16000)  # Input is 16000
+        writer = _RecordingAudioWriter()
+        stage = BackgroundNoiseAugmentor(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            audio_reader=reader,
+            audio_writer=writer,
+            input_dir=tmp_path,
+            noise_provider=noise_provider,
+            params=_make_params(vary_probability=1.0, volume_min=0.1, volume_max=0.1),
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=16000)
+        import pytest
+        with pytest.raises(ValueError, match="sample.rate"):
+            asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
 
 
 # ---------------------------------------------------------------------------
@@ -457,16 +463,13 @@ class TestGenerateOutput:
 
 class TestSkipPath:
     def test_skip_path_does_not_call_audio_writer_on_second_run(self, tmp_path: Path) -> None:
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav")
-
-        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+        """When noise IS applied, second run skips writing (output unchanged)."""
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav")
         stage, _, writer = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
-            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
             noise_filenames=["traffic.wav"],
         )
         sample = _make_audio_sample(wav_dir=tmp_path)
@@ -479,16 +482,13 @@ class TestSkipPath:
         assert len(writer.calls) == initial_count
 
     def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
-        noise_dir = tmp_path / "noise"
-        _write_noise_wav(noise_dir, "traffic.wav")
-
-        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
-        reader.register_noise_path(noise_dir / "traffic.wav")
-
+        """When noise IS applied, second run returns the same output id."""
+        _write_audio_wav(tmp_path, "TV_ON_Jenny_r100.wav")
         stage, _, _ = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
-            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
             noise_filenames=["traffic.wav"],
         )
         sample = _make_audio_sample(wav_dir=tmp_path)

--- a/ml/test/pipeline/speech/test_background_noise_stage.py
+++ b/ml/test/pipeline/speech/test_background_noise_stage.py
@@ -265,35 +265,20 @@ class TestAppliedValues:
 
 
 # ---------------------------------------------------------------------------
-# TestAppliedValuesNoiseShorterThanAudio
+# TestNoiseStartS
 # ---------------------------------------------------------------------------
 
 
-class TestNoiseShorterThanAudio:
-    def test_noise_start_s_clamped_to_zero_when_noise_shorter_than_audio(
-        self, tmp_path: Path
-    ) -> None:
-        """When noise file is shorter than audio, max_start_s < 0 → clamped to 0.0."""
-        # noise is 0.1s, audio is 0.5s → max_start_s = -0.4s → clamp to 0.0
-        reader = _RecordingAudioReader(
-            sample_rate=16000,
-            audio_duration_s=0.5,
-            noise_duration_s=0.1,
-        )
-        noise_dir = tmp_path / "noise"
-        noise_dir.mkdir()
-        reader.register_noise_path(noise_dir / "short.wav")
-
+class TestNoiseStartS:
+    def test_noise_start_s_is_always_zero(self, tmp_path: Path) -> None:
+        """noise_start_s is always 0.0 — noise is mixed from the start of the file."""
         stage, _, _ = _make_stage(
             tmp_path,
-            noise_dir=noise_dir,
-            audio_reader=reader,
             vary_probability=1.0,
             volume_min=0.1,
             volume_max=0.1,
-            noise_filenames=["short.wav"],
         )
-        sample = _make_audio_sample(wav_dir=tmp_path)
+        sample = _make_audio_sample()
         av = stage._get_applied_values(sample, VariationGenerator(42))
         assert av["noise_start_s"] == 0.0
 
@@ -347,7 +332,7 @@ class TestDeriveId:
 
 class TestGenerateOutput:
     def test_generate_output_calls_audio_reader_for_input_and_noise(self, tmp_path: Path) -> None:
-        """When noise is applied (vary_probability=1.0), reader is called for both noise and audio."""
+        """When noise is applied (vary_probability=1.0), reader is called for both audio and noise."""
         noise_dir = tmp_path / "noise"
         _write_noise_wav(noise_dir, "traffic.wav")
 
@@ -365,12 +350,8 @@ class TestGenerateOutput:
         )
         sample = _make_audio_sample(wav_dir=tmp_path)
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
-        # Should have called reader at least 3 times:
-        # - noise file duration (in _get_applied_values)
-        # - audio duration (in _get_applied_values)
-        # - audio file (in _generate_output)
-        # - noise file (in _generate_output)
-        assert len(reader.calls) >= 3
+        # _generate_output reads the input audio file and the noise file — 2 calls total.
+        assert len(reader.calls) >= 2
 
     def test_generate_output_calls_audio_writer(self, tmp_path: Path) -> None:
         noise_dir = tmp_path / "noise"

--- a/ml/test/pipeline/speech/test_background_noise_stage.py
+++ b/ml/test/pipeline/speech/test_background_noise_stage.py
@@ -6,10 +6,8 @@ import asyncio
 import hashlib
 import sys
 from pathlib import Path
-from typing import Any
 
 import numpy as np
-import pytest
 import soundfile as sf
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
@@ -155,6 +153,7 @@ def _make_stage(
         audio_reader=audio_reader,
         audio_writer=audio_writer,
         input_dir=input_dir,
+        noise_dir=noise_dir,
         noise_provider=noise_provider,
         params=params,
     )
@@ -440,6 +439,7 @@ class TestGenerateOutput:
             audio_reader=_ConstantReader(),
             audio_writer=writer,
             input_dir=tmp_path,
+            noise_dir=noise_dir,
             noise_provider=_FakeNoiseProvider(noise_dir, ["traffic.wav"]),
             params=_make_params(vary_probability=0.0),
         )

--- a/ml/test/pipeline/speech/test_background_noise_stage.py
+++ b/ml/test/pipeline/speech/test_background_noise_stage.py
@@ -1,0 +1,517 @@
+"""Unit tests for BackgroundNoiseAugmentor."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.randomization import VariationGenerator
+from pipeline.core.sample import AudioSample
+from pipeline.io.audio_io import AudioData
+from pipeline.speech.background_noise_stage import BackgroundNoiseAugmentor, NoiseProvider
+from pipeline.stages.params import AddBackgroundNoiseParams
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio_sample(
+    sample_id: str = "TV_ON_Jenny_r100",
+    transcript: str = "TV_ON",
+    sample_rate: int = 16000,
+    duration_s: float = 0.5,
+    wav_dir: Path | None = None,
+) -> AudioSample:
+    content = f"{sample_id}:audio"
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    path = Path(f"{sample_id}.wav")
+    if wav_dir is not None:
+        wav_path = wav_dir / path
+        n_samples = int(sample_rate * duration_s)
+        data = np.zeros(n_samples, dtype=np.float32)
+        sf.write(str(wav_path), data, sample_rate, format="WAV", subtype="PCM_16")
+    return AudioSample(
+        id=sample_id,
+        seed=0,
+        content_hash=content_hash,
+        path=path,
+        parent_content_hash="parent_hash",
+        transcript=transcript,
+        applied_values={},
+    )
+
+
+class _RecordingAudioReader:
+    """Stub AudioReader that returns configured durations per path."""
+
+    def __init__(
+        self,
+        sample_rate: int = 16000,
+        audio_duration_s: float = 0.5,
+        noise_duration_s: float = 2.0,
+    ) -> None:
+        self.calls: list[Path] = []
+        self._sample_rate = sample_rate
+        self._audio_duration_s = audio_duration_s
+        self._noise_duration_s = noise_duration_s
+        # If path stem ends with "noise", return noise duration, else audio duration
+        self._noise_paths: set[Path] = set()
+
+    def register_noise_path(self, path: Path) -> None:
+        self._noise_paths.add(path)
+
+    async def read(self, path: Path) -> AudioData:
+        self.calls.append(path)
+        if path in self._noise_paths or path.parent.name == "noise":
+            n_samples = int(self._sample_rate * self._noise_duration_s)
+        else:
+            n_samples = int(self._sample_rate * self._audio_duration_s)
+        samples = np.zeros(n_samples, dtype=np.float32)
+        return AudioData(samples=samples, sample_rate=self._sample_rate)
+
+
+class _RecordingAudioWriter:
+    """Stub AudioWriter that records write() calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Path, AudioData]] = []
+
+    async def write(self, path: Path, audio: AudioData) -> None:
+        self.calls.append((path, audio))
+        sf.write(str(path), audio.samples, audio.sample_rate, format="WAV", subtype="PCM_16")
+
+
+class _FakeNoiseProvider:
+    """Fake NoiseProvider that returns a fixed list of noise file paths."""
+
+    def __init__(self, noise_dir: Path, filenames: list[str]) -> None:
+        self._noise_dir = noise_dir
+        self._filenames = filenames
+
+    def list_files(self) -> list[Path]:
+        return [self._noise_dir / name for name in self._filenames]
+
+
+def _make_params(
+    vary_probability: float = 0.0,
+    volume_min: float = 0.0,
+    volume_max: float = 0.3,
+) -> AddBackgroundNoiseParams:
+    return AddBackgroundNoiseParams(
+        vary_probability=vary_probability,
+        volume_min=volume_min,
+        volume_max=volume_max,
+    )
+
+
+def _make_stage(
+    output_dir: Path,
+    noise_dir: Path | None = None,
+    *,
+    audio_reader: _RecordingAudioReader | None = None,
+    audio_writer: _RecordingAudioWriter | None = None,
+    input_dir: Path | None = None,
+    noise_provider: _FakeNoiseProvider | None = None,
+    params: AddBackgroundNoiseParams | None = None,
+    vary_probability: float = 0.0,
+    volume_min: float = 0.0,
+    volume_max: float = 0.3,
+    noise_filenames: list[str] | None = None,
+) -> tuple[BackgroundNoiseAugmentor, _RecordingAudioReader, _RecordingAudioWriter]:
+    if audio_reader is None:
+        audio_reader = _RecordingAudioReader()
+    if audio_writer is None:
+        audio_writer = _RecordingAudioWriter()
+    if input_dir is None:
+        input_dir = output_dir
+    if noise_dir is None:
+        noise_dir = output_dir / "noise"
+        noise_dir.mkdir(parents=True, exist_ok=True)
+    if params is None:
+        params = _make_params(
+            vary_probability=vary_probability,
+            volume_min=volume_min,
+            volume_max=volume_max,
+        )
+    if noise_provider is None:
+        if noise_filenames is None:
+            noise_filenames = ["traffic.wav"]
+        noise_provider = _FakeNoiseProvider(noise_dir, noise_filenames)
+    stage = BackgroundNoiseAugmentor(
+        output_dir=output_dir,
+        manifest_store=ManifestStore(),
+        audio_reader=audio_reader,
+        audio_writer=audio_writer,
+        input_dir=input_dir,
+        noise_provider=noise_provider,
+        params=params,
+    )
+    return stage, audio_reader, audio_writer
+
+
+def _write_noise_wav(noise_dir: Path, filename: str, sample_rate: int = 16000, duration_s: float = 2.0) -> Path:
+    noise_dir.mkdir(parents=True, exist_ok=True)
+    path = noise_dir / filename
+    n_samples = int(sample_rate * duration_s)
+    data = (np.random.default_rng(42).random(n_samples) * 2 - 1).astype(np.float32)
+    sf.write(str(path), data, sample_rate, format="WAV", subtype="PCM_16")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# TestAppliedValues
+# ---------------------------------------------------------------------------
+
+
+class TestAppliedValues:
+    def test_applied_values_has_noise_file_key(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert "noise_file" in av
+
+    def test_applied_values_has_noise_start_s_key(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert "noise_start_s" in av
+
+    def test_applied_values_has_noise_volume_key(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert "noise_volume" in av
+
+    def test_applied_values_has_exactly_three_keys(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert set(av.keys()) == {"noise_file", "noise_start_s", "noise_volume"}
+
+    def test_noise_file_always_chosen_when_not_applied(self, tmp_path: Path) -> None:
+        """noise_file is always selected even when should_vary returns False (vary_probability=0)."""
+        stage, _, _ = _make_stage(
+            tmp_path,
+            vary_probability=0.0,
+            noise_filenames=["rain.wav", "traffic.wav"],
+        )
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        # noise_file must be one of the provided filenames
+        assert av["noise_file"] in ["rain.wav", "traffic.wav"]
+
+    def test_noise_file_stored_even_when_volume_is_zero(self, tmp_path: Path) -> None:
+        """noise_file is stored regardless of whether noise is applied."""
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["noise_file"] == "traffic.wav"
+        assert av["noise_volume"] == 0.0
+
+    def test_noise_start_s_zero_when_not_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["noise_start_s"] == 0.0
+
+    def test_noise_volume_zero_when_not_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["noise_volume"] == 0.0
+
+    def test_noise_volume_nonzero_when_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(
+            tmp_path,
+            vary_probability=1.0,
+            volume_min=0.2,
+            volume_max=0.2,
+        )
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["noise_volume"] > 0.0
+
+    def test_noise_file_chosen_from_sorted_list(self, tmp_path: Path) -> None:
+        """choose() operates on sorted filenames for OS-independent determinism."""
+        filenames = ["z_noise.wav", "a_noise.wav", "m_noise.wav"]
+        stage, _, _ = _make_stage(tmp_path, noise_filenames=filenames)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(0))
+        # Must be one of the provided filenames
+        assert av["noise_file"] in filenames
+
+    def test_noise_start_s_stored_as_float(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert isinstance(av["noise_start_s"], float)
+
+    def test_noise_volume_stored_as_float(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert isinstance(av["noise_volume"], float)
+
+
+# ---------------------------------------------------------------------------
+# TestAppliedValuesNoiseShorterThanAudio
+# ---------------------------------------------------------------------------
+
+
+class TestNoiseShorterThanAudio:
+    def test_noise_start_s_clamped_to_zero_when_noise_shorter_than_audio(
+        self, tmp_path: Path
+    ) -> None:
+        """When noise file is shorter than audio, max_start_s < 0 → clamped to 0.0."""
+        # noise is 0.1s, audio is 0.5s → max_start_s = -0.4s → clamp to 0.0
+        reader = _RecordingAudioReader(
+            sample_rate=16000,
+            audio_duration_s=0.5,
+            noise_duration_s=0.1,
+        )
+        noise_dir = tmp_path / "noise"
+        noise_dir.mkdir()
+        reader.register_noise_path(noise_dir / "short.wav")
+
+        stage, _, _ = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
+            noise_filenames=["short.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path)
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["noise_start_s"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestDeriveId
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveId:
+    def test_derive_id_format_with_noise_applied(self, tmp_path: Path) -> None:
+        """Format: {input.id}_{noise_filestem}_v{int(volume*100)}"""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {"noise_file": "traffic.wav", "noise_start_s": 0.5, "noise_volume": 0.25})
+        assert result == "TV_ON_Jenny_r100_traffic_v25"
+
+    def test_derive_id_format_with_zero_volume(self, tmp_path: Path) -> None:
+        """Even when volume=0 (not applied), the filestem is still in the id."""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {"noise_file": "rain.wav", "noise_start_s": 0.0, "noise_volume": 0.0})
+        assert result == "TV_ON_Jenny_r100_rain_v0"
+
+    def test_derive_id_uses_stem_not_full_filename(self, tmp_path: Path) -> None:
+        """noise_filestem = Path(noise_file).stem — extension excluded."""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="X")
+        result = stage._derive_id(sample, {"noise_file": "background_noise.wav", "noise_start_s": 0.0, "noise_volume": 0.1})
+        assert "background_noise" in result
+        assert ".wav" not in result
+
+    def test_derive_id_volume_int_conversion(self, tmp_path: Path) -> None:
+        """int(volume * 100): 0.3 → 30, 0.25 → 25."""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="S")
+        result = stage._derive_id(sample, {"noise_file": "t.wav", "noise_start_s": 0.0, "noise_volume": 0.3})
+        assert result == "S_t_v30"
+
+    def test_derive_id_uses_input_id_as_prefix(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="VOLUME_UP_Aria_r110")
+        result = stage._derive_id(sample, {"noise_file": "cafe.wav", "noise_start_s": 0.0, "noise_volume": 0.0})
+        assert result.startswith("VOLUME_UP_Aria_r110_")
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateOutput
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOutput:
+    def test_generate_output_calls_audio_reader_for_input_and_noise(self, tmp_path: Path) -> None:
+        """When noise is applied (vary_probability=1.0), reader is called for both noise and audio."""
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav")
+
+        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, _ = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        # Should have called reader at least 3 times:
+        # - noise file duration (in _get_applied_values)
+        # - audio duration (in _get_applied_values)
+        # - audio file (in _generate_output)
+        # - noise file (in _generate_output)
+        assert len(reader.calls) >= 3
+
+    def test_generate_output_calls_audio_writer(self, tmp_path: Path) -> None:
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav")
+
+        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, writer = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == 1
+
+    def test_output_audio_same_length_as_input(self, tmp_path: Path) -> None:
+        """Background noise does not change the length of the audio."""
+        sample_rate = 16000
+        duration_s = 0.5
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav", sample_rate=sample_rate, duration_s=2.0)
+
+        reader = _RecordingAudioReader(
+            sample_rate=sample_rate, audio_duration_s=duration_s, noise_duration_s=2.0
+        )
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, writer = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            vary_probability=1.0,
+            volume_min=0.1,
+            volume_max=0.1,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        _path, written_audio = writer.calls[0]
+        assert len(written_audio.samples) == int(sample_rate * duration_s)
+
+    def test_output_audio_unchanged_when_volume_is_zero(self, tmp_path: Path) -> None:
+        """When noise not applied (volume=0), output samples equal input samples."""
+        sample_rate = 16000
+        duration_s = 0.1
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav", sample_rate=sample_rate, duration_s=2.0)
+
+        # Use a special reader that returns a known nonzero signal for audio
+        class _ConstantReader:
+            async def read(self, path: Path) -> AudioData:
+                n = int(sample_rate * duration_s)
+                if path.parent.name == "noise":
+                    samples = np.ones(int(sample_rate * 2.0), dtype=np.float32) * 0.9
+                else:
+                    samples = np.full(n, 0.5, dtype=np.float32)
+                return AudioData(samples=samples, sample_rate=sample_rate)
+
+        writer = _RecordingAudioWriter()
+        stage = BackgroundNoiseAugmentor(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            audio_reader=_ConstantReader(),
+            audio_writer=writer,
+            input_dir=tmp_path,
+            noise_provider=_FakeNoiseProvider(noise_dir, ["traffic.wav"]),
+            params=_make_params(vary_probability=0.0),
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        _path, written_audio = writer.calls[0]
+        # All samples should still be 0.5 (unchanged)
+        assert np.allclose(written_audio.samples, 0.5)
+
+    def test_transcript_preserved_in_output_sample(self, tmp_path: Path) -> None:
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav")
+
+        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, _ = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(transcript="VOLUME_UP", wav_dir=tmp_path)
+        result = asyncio.run(
+            stage.transform(Manifest([sample]), tmp_path / "manifest.json")
+        )
+        assert result.samples[0].transcript == "VOLUME_UP"
+
+
+# ---------------------------------------------------------------------------
+# TestSkipPath
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPath:
+    def test_skip_path_does_not_call_audio_writer_on_second_run(self, tmp_path: Path) -> None:
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav")
+
+        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, writer = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path)
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        initial_count = len(writer.calls)
+        assert initial_count == 1
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == initial_count
+
+    def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
+        noise_dir = tmp_path / "noise"
+        _write_noise_wav(noise_dir, "traffic.wav")
+
+        reader = _RecordingAudioReader(audio_duration_s=0.5, noise_duration_s=2.0)
+        reader.register_noise_path(noise_dir / "traffic.wav")
+
+        stage, _, _ = _make_stage(
+            tmp_path,
+            noise_dir=noise_dir,
+            audio_reader=reader,
+            noise_filenames=["traffic.wav"],
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path)
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].id == result1.samples[0].id

--- a/ml/test/pipeline/speech/test_mic_noise_stage.py
+++ b/ml/test/pipeline/speech/test_mic_noise_stage.py
@@ -6,10 +6,8 @@ import asyncio
 import hashlib
 import sys
 from pathlib import Path
-from typing import Any
 
 import numpy as np
-import pytest
 import soundfile as sf
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))

--- a/ml/test/pipeline/speech/test_mic_noise_stage.py
+++ b/ml/test/pipeline/speech/test_mic_noise_stage.py
@@ -1,0 +1,330 @@
+"""Unit tests for MicrophoneNoiseAugmentor."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.randomization import VariationGenerator
+from pipeline.core.sample import AudioSample
+from pipeline.io.audio_io import AudioData
+from pipeline.speech.mic_noise_stage import MicrophoneNoiseAugmentor
+from pipeline.stages.params import AddMicNoiseParams
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio_sample(
+    sample_id: str = "TV_ON_Jenny_r100",
+    transcript: str = "TV_ON",
+    sample_rate: int = 16000,
+    duration_s: float = 0.1,
+    wav_dir: Path | None = None,
+) -> AudioSample:
+    content = f"{sample_id}:audio"
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    path = Path(f"{sample_id}.wav")
+    if wav_dir is not None:
+        wav_path = wav_dir / path
+        n_samples = int(sample_rate * duration_s)
+        data = np.zeros(n_samples, dtype=np.float32)
+        sf.write(str(wav_path), data, sample_rate, format="WAV", subtype="PCM_16")
+    return AudioSample(
+        id=sample_id,
+        seed=0,
+        content_hash=content_hash,
+        path=path,
+        parent_content_hash="parent_hash",
+        transcript=transcript,
+        applied_values={},
+    )
+
+
+class _RecordingAudioReader:
+    """Stub AudioReader that records read() calls and returns silence."""
+
+    def __init__(self, sample_rate: int = 16000, duration_s: float = 0.1) -> None:
+        self.calls: list[Path] = []
+        self._sample_rate = sample_rate
+        self._duration_s = duration_s
+
+    async def read(self, path: Path) -> AudioData:
+        self.calls.append(path)
+        n_samples = int(self._sample_rate * self._duration_s)
+        samples = np.zeros(n_samples, dtype=np.float32)
+        return AudioData(samples=samples, sample_rate=self._sample_rate)
+
+
+class _RecordingAudioWriter:
+    """Stub AudioWriter that records write() calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Path, AudioData]] = []
+
+    async def write(self, path: Path, audio: AudioData) -> None:
+        self.calls.append((path, audio))
+        sf.write(str(path), audio.samples, audio.sample_rate, format="WAV", subtype="PCM_16")
+
+
+def _make_params(
+    vary_probability: float = 0.0,
+    amplitude_min: float = 0.001,
+    amplitude_max: float = 0.05,
+) -> AddMicNoiseParams:
+    return AddMicNoiseParams(
+        vary_probability=vary_probability,
+        amplitude_min=amplitude_min,
+        amplitude_max=amplitude_max,
+    )
+
+
+def _make_stage(
+    output_dir: Path,
+    *,
+    audio_reader: _RecordingAudioReader | None = None,
+    audio_writer: _RecordingAudioWriter | None = None,
+    input_dir: Path | None = None,
+    params: AddMicNoiseParams | None = None,
+    vary_probability: float = 0.0,
+    amplitude_min: float = 0.001,
+    amplitude_max: float = 0.05,
+) -> tuple[MicrophoneNoiseAugmentor, _RecordingAudioReader, _RecordingAudioWriter]:
+    if audio_reader is None:
+        audio_reader = _RecordingAudioReader()
+    if audio_writer is None:
+        audio_writer = _RecordingAudioWriter()
+    if input_dir is None:
+        input_dir = output_dir
+    if params is None:
+        params = _make_params(
+            vary_probability=vary_probability,
+            amplitude_min=amplitude_min,
+            amplitude_max=amplitude_max,
+        )
+    stage = MicrophoneNoiseAugmentor(
+        output_dir=output_dir,
+        manifest_store=ManifestStore(),
+        audio_reader=audio_reader,
+        audio_writer=audio_writer,
+        input_dir=input_dir,
+        params=params,
+    )
+    return stage, audio_reader, audio_writer
+
+
+# ---------------------------------------------------------------------------
+# TestAppliedValues
+# ---------------------------------------------------------------------------
+
+
+class TestAppliedValues:
+    def test_applied_values_has_mic_noise_amplitude_key(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert "mic_noise_amplitude" in av
+
+    def test_applied_values_has_exactly_one_key(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert set(av.keys()) == {"mic_noise_amplitude"}
+
+    def test_amplitude_zero_when_not_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0, amplitude_min=0.01, amplitude_max=0.05)
+        sample = _make_audio_sample()
+        for seed in range(10):
+            av = stage._get_applied_values(sample, VariationGenerator(seed))
+            assert av["mic_noise_amplitude"] == 0.0
+
+    def test_amplitude_nonzero_when_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["mic_noise_amplitude"] > 0.0
+
+    def test_amplitude_stored_as_float(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert isinstance(av["mic_noise_amplitude"], float)
+
+    def test_amplitude_zero_stored_as_float_not_int(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        av = stage._get_applied_values(sample, VariationGenerator(42))
+        assert av["mic_noise_amplitude"] == 0.0
+        assert isinstance(av["mic_noise_amplitude"], float)
+
+
+# ---------------------------------------------------------------------------
+# TestDeriveId
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveId:
+    def test_derive_id_format_with_noise_applied(self, tmp_path: Path) -> None:
+        """Format: {input.id}_mic{int(amplitude*1000)}"""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.025})
+        assert result == "TV_ON_Jenny_r100_mic25"
+
+    def test_derive_id_format_with_zero_amplitude(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.0})
+        assert result == "TV_ON_Jenny_r100_mic0"
+
+    def test_derive_id_uses_input_id_as_prefix(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="VOLUME_UP_Aria_r110")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.0})
+        assert result.startswith("VOLUME_UP_Aria_r110_")
+
+    def test_derive_id_amplitude_int_conversion(self, tmp_path: Path) -> None:
+        """int(amplitude * 1000): 0.05 → 50, 0.001 → 1."""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="S")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.05})
+        assert result == "S_mic50"
+
+    def test_derive_id_always_has_mic_suffix(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="X")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.01})
+        assert "_mic" in result
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateOutput
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOutput:
+    def test_generate_output_calls_audio_reader(self, tmp_path: Path) -> None:
+        stage, reader, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(wav_dir=tmp_path)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1
+
+    def test_generate_output_calls_audio_writer(self, tmp_path: Path) -> None:
+        stage, _, writer = _make_stage(tmp_path)
+        sample = _make_audio_sample(wav_dir=tmp_path)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == 1
+
+    def test_output_audio_same_length_as_input(self, tmp_path: Path) -> None:
+        """Mic noise does not change the length of the audio."""
+        sample_rate = 16000
+        duration_s = 0.1
+        stage, _, writer = _make_stage(
+            tmp_path,
+            audio_reader=_RecordingAudioReader(sample_rate=sample_rate, duration_s=duration_s),
+            vary_probability=1.0,
+            amplitude_min=0.01,
+            amplitude_max=0.01,
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        _path, written_audio = writer.calls[0]
+        assert len(written_audio.samples) == int(sample_rate * duration_s)
+
+    def test_output_audio_unchanged_when_amplitude_is_zero(self, tmp_path: Path) -> None:
+        """When noise not applied (amplitude=0), output samples equal input samples."""
+        sample_rate = 16000
+        duration_s = 0.1
+
+        class _ConstantReader:
+            async def read(self, path: Path) -> AudioData:
+                n = int(sample_rate * duration_s)
+                return AudioData(samples=np.full(n, 0.5, dtype=np.float32), sample_rate=sample_rate)
+
+        writer = _RecordingAudioWriter()
+        stage = MicrophoneNoiseAugmentor(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            audio_reader=_ConstantReader(),
+            audio_writer=writer,
+            input_dir=tmp_path,
+            params=_make_params(vary_probability=0.0),
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        _path, written_audio = writer.calls[0]
+        assert np.allclose(written_audio.samples, 0.5)
+
+    def test_gaussian_noise_added_when_amplitude_nonzero(self, tmp_path: Path) -> None:
+        """When amplitude > 0, output should differ from input (noise was added)."""
+        sample_rate = 16000
+        duration_s = 0.5  # Long enough for statistical significance
+        amplitude = 0.1
+
+        class _ZeroReader:
+            async def read(self, path: Path) -> AudioData:
+                n = int(sample_rate * duration_s)
+                return AudioData(samples=np.zeros(n, dtype=np.float32), sample_rate=sample_rate)
+
+        writer = _RecordingAudioWriter()
+        stage = MicrophoneNoiseAugmentor(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            audio_reader=_ZeroReader(),
+            audio_writer=writer,
+            input_dir=tmp_path,
+            params=_make_params(vary_probability=1.0, amplitude_min=amplitude, amplitude_max=amplitude),
+        )
+        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        _path, written_audio = writer.calls[0]
+        # Noise was added — not all zeros anymore
+        assert not np.all(written_audio.samples == 0.0)
+
+    def test_transcript_preserved_in_output_sample(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(transcript="CHANNEL_UP", wav_dir=tmp_path)
+        result = asyncio.run(
+            stage.transform(Manifest([sample]), tmp_path / "manifest.json")
+        )
+        assert result.samples[0].transcript == "CHANNEL_UP"
+
+
+# ---------------------------------------------------------------------------
+# TestSkipPath
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPath:
+    def test_skip_path_does_not_call_audio_writer_on_second_run(self, tmp_path: Path) -> None:
+        stage, _, writer = _make_stage(tmp_path)
+        sample = _make_audio_sample(wav_dir=tmp_path)
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        initial_count = len(writer.calls)
+        assert initial_count == 1
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == initial_count
+
+    def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(wav_dir=tmp_path)
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].id == result1.samples[0].id

--- a/ml/test/pipeline/speech/test_mic_noise_stage.py
+++ b/ml/test/pipeline/speech/test_mic_noise_stage.py
@@ -177,22 +177,23 @@ class TestAppliedValues:
 
 class TestDeriveId:
     def test_derive_id_format_with_noise_applied(self, tmp_path: Path) -> None:
-        """Format: {input.id}_mic{int(amplitude*1000)}"""
+        """Format: {input.id}_mic{int(amplitude*1000)} when amplitude > 0."""
         stage, _, _ = _make_stage(tmp_path)
         sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
         result = stage._derive_id(sample, {"mic_noise_amplitude": 0.025})
         assert result == "TV_ON_Jenny_r100_mic25"
 
-    def test_derive_id_format_with_zero_amplitude(self, tmp_path: Path) -> None:
+    def test_derive_id_format_with_zero_amplitude_is_input_id(self, tmp_path: Path) -> None:
+        """When amplitude == 0 (no noise), id equals input id — no suffix added."""
         stage, _, _ = _make_stage(tmp_path)
         sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
         result = stage._derive_id(sample, {"mic_noise_amplitude": 0.0})
-        assert result == "TV_ON_Jenny_r100_mic0"
+        assert result == "TV_ON_Jenny_r100"
 
     def test_derive_id_uses_input_id_as_prefix(self, tmp_path: Path) -> None:
         stage, _, _ = _make_stage(tmp_path)
         sample = _make_audio_sample(sample_id="VOLUME_UP_Aria_r110")
-        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.0})
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.01})
         assert result.startswith("VOLUME_UP_Aria_r110_")
 
     def test_derive_id_amplitude_int_conversion(self, tmp_path: Path) -> None:
@@ -202,11 +203,18 @@ class TestDeriveId:
         result = stage._derive_id(sample, {"mic_noise_amplitude": 0.05})
         assert result == "S_mic50"
 
-    def test_derive_id_always_has_mic_suffix(self, tmp_path: Path) -> None:
+    def test_derive_id_always_has_mic_suffix_when_nonzero(self, tmp_path: Path) -> None:
         stage, _, _ = _make_stage(tmp_path)
         sample = _make_audio_sample(sample_id="X")
         result = stage._derive_id(sample, {"mic_noise_amplitude": 0.01})
         assert "_mic" in result
+
+    def test_derive_id_no_mic_suffix_when_zero(self, tmp_path: Path) -> None:
+        """No _mic suffix when amplitude is zero."""
+        stage, _, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="X")
+        result = stage._derive_id(sample, {"mic_noise_amplitude": 0.0})
+        assert "_mic" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -215,14 +223,40 @@ class TestDeriveId:
 
 
 class TestGenerateOutput:
-    def test_generate_output_calls_audio_reader(self, tmp_path: Path) -> None:
-        stage, reader, _ = _make_stage(tmp_path)
+    def test_generate_output_does_not_call_reader_when_amplitude_is_zero(self, tmp_path: Path) -> None:
+        """When amplitude == 0, no audio reading occurs."""
+        stage, reader, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 0
+
+    def test_generate_output_does_not_call_writer_when_amplitude_is_zero(self, tmp_path: Path) -> None:
+        """When amplitude == 0, no file is written."""
+        stage, _, writer = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(writer.calls) == 0
+
+    def test_generate_output_returns_input_when_amplitude_is_zero(self, tmp_path: Path) -> None:
+        """When amplitude == 0, transform returns the original input sample."""
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].id == sample.id
+        assert result.samples[0].path == sample.path
+
+    def test_generate_output_calls_audio_reader_when_amplitude_nonzero(self, tmp_path: Path) -> None:
+        stage, reader, _ = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
         sample = _make_audio_sample(wav_dir=tmp_path)
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         assert len(reader.calls) == 1
 
-    def test_generate_output_calls_audio_writer(self, tmp_path: Path) -> None:
-        stage, _, writer = _make_stage(tmp_path)
+    def test_generate_output_calls_audio_writer_when_amplitude_nonzero(self, tmp_path: Path) -> None:
+        stage, _, writer = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
         sample = _make_audio_sample(wav_dir=tmp_path)
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         assert len(writer.calls) == 1
@@ -242,30 +276,6 @@ class TestGenerateOutput:
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         _path, written_audio = writer.calls[0]
         assert len(written_audio.samples) == int(sample_rate * duration_s)
-
-    def test_output_audio_unchanged_when_amplitude_is_zero(self, tmp_path: Path) -> None:
-        """When noise not applied (amplitude=0), output samples equal input samples."""
-        sample_rate = 16000
-        duration_s = 0.1
-
-        class _ConstantReader:
-            async def read(self, path: Path) -> AudioData:
-                n = int(sample_rate * duration_s)
-                return AudioData(samples=np.full(n, 0.5, dtype=np.float32), sample_rate=sample_rate)
-
-        writer = _RecordingAudioWriter()
-        stage = MicrophoneNoiseAugmentor(
-            output_dir=tmp_path,
-            manifest_store=ManifestStore(),
-            audio_reader=_ConstantReader(),
-            audio_writer=writer,
-            input_dir=tmp_path,
-            params=_make_params(vary_probability=0.0),
-        )
-        sample = _make_audio_sample(wav_dir=tmp_path, sample_rate=sample_rate, duration_s=duration_s)
-        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
-        _path, written_audio = writer.calls[0]
-        assert np.allclose(written_audio.samples, 0.5)
 
     def test_gaussian_noise_added_when_amplitude_nonzero(self, tmp_path: Path) -> None:
         """When amplitude > 0, output should differ from input (noise was added)."""
@@ -293,13 +303,23 @@ class TestGenerateOutput:
         # Noise was added — not all zeros anymore
         assert not np.all(written_audio.samples == 0.0)
 
-    def test_transcript_preserved_in_output_sample(self, tmp_path: Path) -> None:
-        stage, _, _ = _make_stage(tmp_path)
+    def test_transcript_preserved_when_noise_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
         sample = _make_audio_sample(transcript="CHANNEL_UP", wav_dir=tmp_path)
         result = asyncio.run(
             stage.transform(Manifest([sample]), tmp_path / "manifest.json")
         )
         assert result.samples[0].transcript == "CHANNEL_UP"
+
+    def test_transcript_preserved_when_not_applied(self, tmp_path: Path) -> None:
+        stage, _, _ = _make_stage(tmp_path, vary_probability=0.0)
+        sample = _make_audio_sample(transcript="CHANNEL_DOWN")
+        result = asyncio.run(
+            stage.transform(Manifest([sample]), tmp_path / "manifest.json")
+        )
+        assert result.samples[0].transcript == "CHANNEL_DOWN"
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +329,10 @@ class TestGenerateOutput:
 
 class TestSkipPath:
     def test_skip_path_does_not_call_audio_writer_on_second_run(self, tmp_path: Path) -> None:
-        stage, _, writer = _make_stage(tmp_path)
+        """When noise IS applied, second run skips writing (output unchanged)."""
+        stage, _, writer = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
         sample = _make_audio_sample(wav_dir=tmp_path)
 
         asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
@@ -320,7 +343,10 @@ class TestSkipPath:
         assert len(writer.calls) == initial_count
 
     def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
-        stage, _, _ = _make_stage(tmp_path)
+        """When noise IS applied, second run returns the same output id."""
+        stage, _, _ = _make_stage(
+            tmp_path, vary_probability=1.0, amplitude_min=0.01, amplitude_max=0.01
+        )
         sample = _make_audio_sample(wav_dir=tmp_path)
 
         result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))

--- a/ml/test/pipeline/stages/test_params.py
+++ b/ml/test/pipeline/stages/test_params.py
@@ -10,7 +10,14 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
-from pipeline.stages.params import AddDelaysParams, GeneratePhraseParams, GenerateSamplesParams, PipelineParams
+from pipeline.stages.params import (
+    AddBackgroundNoiseParams,
+    AddDelaysParams,
+    AddMicNoiseParams,
+    GeneratePhraseParams,
+    GenerateSamplesParams,
+    PipelineParams,
+)
 
 
 def _write_params(path: Path, data: dict) -> Path:
@@ -43,6 +50,16 @@ _VALID_DATA = {
             "suffix_vary_probability": 0.333,
             "suffix_min_s": 0.02,
             "suffix_max_s": 0.15,
+        },
+        "add_background_noise": {
+            "vary_probability": 0.5,
+            "volume_min": 0.0,
+            "volume_max": 0.3,
+        },
+        "add_mic_noise": {
+            "vary_probability": 0.5,
+            "amplitude_min": 0.001,
+            "amplitude_max": 0.05,
         },
     },
 }
@@ -153,3 +170,71 @@ class TestAddDelaysParamsLoad:
         assert isinstance(ad.suffix_vary_probability, float)
         assert isinstance(ad.suffix_min_s, float)
         assert isinstance(ad.suffix_max_s, float)
+
+
+class TestAddBackgroundNoiseParamsLoad:
+    def test_loads_add_background_noise_fields(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        bn = params.add_background_noise
+        assert bn.vary_probability == pytest.approx(0.5)
+        assert bn.volume_min == pytest.approx(0.0)
+        assert bn.volume_max == pytest.approx(0.3)
+
+    def test_add_background_noise_is_correct_type(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.add_background_noise, AddBackgroundNoiseParams)
+
+    def test_add_background_noise_fields_are_floats(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        bn = params.add_background_noise
+        assert isinstance(bn.vary_probability, float)
+        assert isinstance(bn.volume_min, float)
+        assert isinstance(bn.volume_max, float)
+
+    def test_missing_add_background_noise_stage_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["stages"]["add_background_noise"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)
+
+
+class TestAddMicNoiseParamsLoad:
+    def test_loads_add_mic_noise_fields(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        mn = params.add_mic_noise
+        assert mn.vary_probability == pytest.approx(0.5)
+        assert mn.amplitude_min == pytest.approx(0.001)
+        assert mn.amplitude_max == pytest.approx(0.05)
+
+    def test_add_mic_noise_is_correct_type(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.add_mic_noise, AddMicNoiseParams)
+
+    def test_add_mic_noise_fields_are_floats(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        mn = params.add_mic_noise
+        assert isinstance(mn.vary_probability, float)
+        assert isinstance(mn.amplitude_min, float)
+        assert isinstance(mn.amplitude_max, float)
+
+    def test_missing_add_mic_noise_stage_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["stages"]["add_mic_noise"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)

--- a/ml/test/pipeline/stages/test_params.py
+++ b/ml/test/pipeline/stages/test_params.py
@@ -30,6 +30,7 @@ _VALID_DATA = {
     "pipeline": {
         "variations_per_phrase": 20,
         "subsample_rate": 200,
+        "sample_rate": 16000,
     },
     "stages": {
         "generate_phrases": {
@@ -72,6 +73,20 @@ class TestPipelineParamsLoad:
 
         assert params.variations_per_phrase == 20
         assert params.subsample_rate == 200
+        assert params.sample_rate == 16000
+
+    def test_sample_rate_is_int(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+        assert isinstance(params.sample_rate, int)
+
+    def test_missing_sample_rate_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["pipeline"]["sample_rate"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)
 
     def test_loads_generate_phrases_fields(self, tmp_path: Path) -> None:
         params_file = _write_params(tmp_path, _VALID_DATA)


### PR DESCRIPTION
**Work item:** ADR-227 — Implement `BackgroundNoiseAugmentor` and `MicrophoneNoiseAugmentor`, two `ModifierStage` subclasses that add environmental noise and microphone noise to `AudioSample` manifests, along with their DVC entry-point scripts.

## Changes

- `ml/pipeline/speech/background_noise_stage.py` — New file: `NoiseProvider` protocol and `BackgroundNoiseAugmentor(ModifierStage[AudioSample, AudioSample])`. `choose()` always called for hash stability; all three applied_values keys always present; `noise_start_s` bounds derived from runtime file durations via `AudioReader`.
- `ml/pipeline/speech/mic_noise_stage.py` — New file: `MicrophoneNoiseAugmentor(ModifierStage[AudioSample, AudioSample])`. Generates Gaussian noise seeded from `output_seed`. Single applied_values key: `mic_noise_amplitude`.
- `ml/pipeline/stages/speech_05_add_background_noise.py` — New entry-point: `--input-manifest-dir`, `--noise-dir`, `--output-dir`; constructs `BackgroundNoiseAugmentor` with `_DirectoryNoiseProvider`.
- `ml/pipeline/stages/speech_06_add_mic_noise.py` — New entry-point: `--input-manifest-dir`, `--output-dir`; constructs `MicrophoneNoiseAugmentor`.
- `ml/pipeline/stages/params.py` — Added `AddBackgroundNoiseParams` and `AddMicNoiseParams` dataclasses; extended `PipelineParams` and `PipelineParams.load()` to parse the new sections.
- `ml/params.yaml` — Added `stages.add_background_noise` and `stages.add_mic_noise` sections with default values.
- `ml/pipeline/speech/_doc_speech.md` — Updated stages table to include both new stages; added design decisions for `NoiseProvider`, hash-stable noise file selection, runtime duration bounds, and Gaussian mic noise seeding.
- `ml/test/pipeline/speech/test_background_noise_stage.py` — New unit tests for `BackgroundNoiseAugmentor` (applied_values keys, noise_start_s clamping, derive_id format, generate_output, skip path).
- `ml/test/pipeline/speech/test_mic_noise_stage.py` — New unit tests for `MicrophoneNoiseAugmentor` (applied_values keys, derive_id format, generate_output, skip path).
- `ml/test/pipeline/stages/test_params.py` — Added `TestAddBackgroundNoiseParamsLoad` and `TestAddMicNoiseParamsLoad` test classes.

## Design decisions

- **`choose()` is always called regardless of `should_vary`.** The noise filename is always selected and stored in `applied_values` for hash stability. Only `noise_start_s` and `noise_volume` are set to 0.0 when the variation is not applied. All three keys are always present.
- **`noise_start_s` bounds are derived at runtime from file durations.** `AudioReader` is called for both the noise file and the audio sample. When the noise file is shorter than the audio sample, `max_start_s` is forced to 0.0.
- **Async duration reads in a synchronous context.** `_get_applied_values` is synchronous per the base class contract. A `_read_duration_s()` helper detects whether a running event loop exists and uses `ThreadPoolExecutor` + `asyncio.run()` accordingly, satisfying both test and production paths.
- **Noise mixing clips to `[-1.0, 1.0]`.** The spec did not specify clipping; this is the standard approach and was recommended in the brief.
- **Gaussian mic noise** seeded from `output_seed` via `np.random.default_rng(output_seed).normal(0, amplitude, len(samples))` for reproducibility.
- **`dvc.yaml` wiring is out of scope** — deferred to ADR-231 per the brief.