### PR TITLE
ADR-228: SpectrogramStage, TokenStage, SetManifestSplitter and DVC entry-points

### DIFF
--- a/ml/params.yaml
+++ b/ml/params.yaml
@@ -29,3 +29,12 @@ stages:
     vary_probability: 0.5
     amplitude_min: 0.001
     amplitude_max: 0.05
+  compute_spectrograms:
+    n_mels: 128
+    time_steps: 256
+  compute_tokens:
+    input_token_length: 50
+  create_set_manifests:
+    train_pct: 70
+    val_pct: 20
+    test_pct: 10

--- a/ml/pipeline/speech/_doc_speech.md
+++ b/ml/pipeline/speech/_doc_speech.md
@@ -1,21 +1,33 @@
 ## Summary: ml/pipeline/speech
 
-Speech augmentation stages for the OOP pipeline. Each stage is a `ModifierStage`
-subtype that takes an `AudioSample` manifest (or `TextSample` for the TTS stage) and
-produces a derived `AudioSample` manifest with per-sample variation applied.
+Speech pipeline stages for the OOP pipeline. The directory contains two cohorts:
+
+- **Augmentation stages** — `ModifierStage` subtypes that take an `AudioSample` (or
+  `TextSample`) manifest and produce a derived `AudioSample` manifest with per-sample
+  variation applied. These are non-deterministic: each variant has a unique `id` and
+  `content_hash`.
+- **Featurisation stages** — deterministic `ModifierStage` subtypes that convert
+  `AudioSample` manifests into model-ready feature manifests (`SampleSpectrogram`,
+  `SampleTokens`). The output `id` equals the input `AudioSample.id` (same stem,
+  different extension), and `_get_applied_values` returns `{}`.
+- **Splitter** — `SetManifestSplitter`, a plain (non-stage) class that partitions a
+  fully-augmented `AudioSample` manifest into train/val/test subsets.
 
 ## Stages
 
-| Module | Stage class | Transform |
-|--------|-------------|-----------|
+| Module | Class | Transform |
+|--------|-------|-----------|
 | [`tts_stage.py`](tts_stage.py) | `TtsSampleGenerator` | `TextSample → AudioSample` via edge_tts |
 | [`delay_stage.py`](delay_stage.py) | `DelayAugmentor` | `AudioSample → AudioSample` (silence padding) |
 | [`background_noise_stage.py`](background_noise_stage.py) | `BackgroundNoiseAugmentor` | `AudioSample → AudioSample` (environmental noise mix) |
 | [`mic_noise_stage.py`](mic_noise_stage.py) | `MicrophoneNoiseAugmentor` | `AudioSample → AudioSample` (Gaussian mic noise) |
-
-Planned stages (not yet implemented): `token_stage.py`, `spectrogram_stage.py`.
+| [`spectrogram_stage.py`](spectrogram_stage.py) | `SpectrogramStage` | `AudioSample → SampleSpectrogram` (log-mel `.npy`) |
+| [`token_stage.py`](token_stage.py) | `TokenStage` | `AudioSample → SampleTokens` (phoneme token `.json`) |
+| [`set_splitter.py`](set_splitter.py) | `SetManifestSplitter` | Split augmented manifest into train/val/test |
 
 ## Key design decisions
+
+### Augmentation stages
 
 **`TtsProvider` protocol as the synthesis seam.** `TtsSampleGenerator` accepts a
 `TtsProvider` and never imports `edge_tts` directly — unit tests supply a stub, the
@@ -52,3 +64,44 @@ keys (`noise_file`, `noise_start_s`, `noise_volume`) are always present in `appl
 **Gaussian noise in `MicrophoneNoiseAugmentor` is seeded from `output_seed`.** Uses
 `np.random.default_rng(output_seed).normal(0, amplitude, len(samples))` for
 reproducibility. The amplitude is stored as 0.0 when not applied.
+
+### Featurisation stages
+
+**`_is_deterministic = True` on both featurisation stages.** `ModifierStage` uses this
+flag to force `output_seed = 0`. Because the transform is fully determined by the input
+audio or transcript, no random variation is needed and `_get_applied_values` returns `{}`.
+
+**`_derive_id` returns `input_sample.id` unchanged.** Featurisation stages preserve the
+input filename stem (different extension: `.npy` for spectrograms, `.json` for tokens).
+This differs from augmentation stages, which append a suffix to make each variant's id
+unique. The shared `id` is what downstream consumers (`ModelTrainer`, `ModelEvaluator`)
+use to join each feature file back to the split manifests.
+
+**`SampleSpectrogram.parent_id` and `SampleTokens.parent_id` = `input_sample.id`.**
+Set from the input `AudioSample.id`, not the `content_hash`. Used downstream to join
+spectrogram/token outputs to the corresponding `AudioSample` in the split manifests.
+
+**Spectrogram padding/truncation.** `SpectrogramStage` applies `librosa.power_to_db`
+after `librosa.feature.melspectrogram`, then zero-pads short frames on the right
+(`np.pad(mode='constant')`) or truncates long frames from the right (`log_s[:, :time_steps]`).
+Output shape is always `(n_mels, time_steps)`.
+
+**Blocking compute offloaded to thread pool.** Both the mel spectrogram computation
+(`librosa.feature.melspectrogram`) and the file writes (`np.save`, `write_text`) are
+offloaded via `asyncio.get_running_loop().run_in_executor(None, ...)` to avoid blocking
+the event loop.
+
+### SetManifestSplitter
+
+**Splits the fully-augmented manifest, not clean audio.** The splitter receives the
+`MicrophoneNoiseAugmentor` output manifest — the complete augmented dataset — before any
+feature extraction. This ensures every augmented variant ends up in exactly one split.
+
+**`seed=42` by default; uses stdlib `random.Random`, not numpy.** Shuffling is a pure
+ordering operation with no numerical distribution requirements. `random.Random` is
+sufficient and avoids adding a numpy dependency on a non-numerical operation.
+
+**Writes via `conventions.split_manifest_path`.** Output filenames are
+`train_manifest.json`, `val_manifest.json`, and `test_manifest.json` (the `_manifest`
+suffix is required by `conventions.split_manifest_path`). `AudioSample.id` values are
+preserved unchanged — no re-assignment in split outputs.

--- a/ml/pipeline/speech/set_splitter.py
+++ b/ml/pipeline/speech/set_splitter.py
@@ -55,8 +55,8 @@ class SetManifestSplitter:
         rng.shuffle(samples)
 
         n = len(samples)
-        train_end = round(n * train_pct / 100)
-        val_end = train_end + round(n * val_pct / 100)
+        train_end = int(n * train_pct / 100)
+        val_end = train_end + int(n * val_pct / 100)
 
         train_samples = samples[:train_end]
         val_samples = samples[train_end:val_end]

--- a/ml/pipeline/speech/set_splitter.py
+++ b/ml/pipeline/speech/set_splitter.py
@@ -1,0 +1,75 @@
+"""SetManifestSplitter: split a fully-augmented manifest into train/val/test subsets.
+
+Shuffles input AudioSample objects using the provided seed, then slices
+by percentage. AudioSample.id values are preserved unchanged in each split.
+Split manifests are written via ManifestStore using conventions.split_manifest_path.
+"""
+
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.sample import AudioSample
+from pipeline.stages import conventions
+
+
+class SetManifestSplitter:
+    """Splits a fully-augmented manifest into train, val, and test subsets.
+
+    Percentages must sum to exactly 100. Samples are shuffled deterministically
+    using the provided seed before slicing.
+
+    Split manifests are written to:
+      output_dir/train_manifest.json
+      output_dir/val_manifest.json
+      output_dir/test_manifest.json
+
+    AudioSample.id values from the input are preserved unchanged.
+    """
+
+    def __init__(self, seed: int = 42) -> None:
+        self._seed = seed
+
+    def split(
+        self,
+        manifest: Manifest[AudioSample],
+        train_pct: int,
+        val_pct: int,
+        test_pct: int,
+        output_dir: Path,
+    ) -> tuple[Manifest[AudioSample], Manifest[AudioSample], Manifest[AudioSample]]:
+        """Shuffle and split manifest; write three manifest files; return split manifests.
+
+        Raises ValueError if train_pct + val_pct + test_pct != 100.
+        """
+        if train_pct + val_pct + test_pct != 100:
+            raise ValueError(
+                f"Percentages must sum to 100, got "
+                f"{train_pct} + {val_pct} + {test_pct} = {train_pct + val_pct + test_pct}"
+            )
+
+        samples = list(manifest.samples)
+        rng = random.Random(self._seed)
+        rng.shuffle(samples)
+
+        n = len(samples)
+        train_end = round(n * train_pct / 100)
+        val_end = train_end + round(n * val_pct / 100)
+
+        train_samples = samples[:train_end]
+        val_samples = samples[train_end:val_end]
+        test_samples = samples[val_end:]
+
+        train_manifest: Manifest[AudioSample] = Manifest(train_samples)
+        val_manifest: Manifest[AudioSample] = Manifest(val_samples)
+        test_manifest: Manifest[AudioSample] = Manifest(test_samples)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        store = ManifestStore()
+        store.write(train_manifest, conventions.split_manifest_path(output_dir, "train"))
+        store.write(val_manifest, conventions.split_manifest_path(output_dir, "val"))
+        store.write(test_manifest, conventions.split_manifest_path(output_dir, "test"))
+
+        return train_manifest, val_manifest, test_manifest

--- a/ml/pipeline/speech/spectrogram_stage.py
+++ b/ml/pipeline/speech/spectrogram_stage.py
@@ -2,8 +2,11 @@
 
 Each AudioSample is transformed into a SampleSpectrogram whose .npy file
 contains an (n_mels, time_steps) float32 array. The stage is deterministic
-(_is_deterministic = True) so output_seed is always 0 and _get_applied_values
-returns an empty dict.
+(_is_deterministic = True) so output_seed is always 0.
+
+_get_applied_values returns {"n_mels": ..., "time_steps": ...} so that changing
+spectrogram dimensions between runs changes the content_hash and triggers regen
+of any previously-cached outputs that used different dimensions.
 
 The mel spectrogram computation (librosa) is offloaded to a thread pool
 executor so the asyncio event loop is not blocked by CPU-bound work.
@@ -31,6 +34,9 @@ class SpectrogramStage(ModifierStage[AudioSample, SampleSpectrogram]):
     Output shape: (n_mels, time_steps). Short spectrograms are zero-padded on
     the right; long spectrograms are truncated from the right.
 
+    _get_applied_values includes n_mels and time_steps so that changes to either
+    invalidate previously-cached outputs via content_hash comparison.
+
     input_dir is the directory containing the WAV files referenced by
     AudioSample.path — typically the output directory of the preceding stage.
     """
@@ -55,7 +61,7 @@ class SpectrogramStage(ModifierStage[AudioSample, SampleSpectrogram]):
     def _get_applied_values(
         self, sample: AudioSample, generator: VariationGenerator
     ) -> dict[str, Any]:
-        return {}
+        return {"n_mels": self._n_mels, "time_steps": self._time_steps}
 
     def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
         return input_sample.id

--- a/ml/pipeline/speech/spectrogram_stage.py
+++ b/ml/pipeline/speech/spectrogram_stage.py
@@ -1,0 +1,109 @@
+"""SpectrogramStage: compute log-mel spectrograms from WAV audio samples.
+
+Each AudioSample is transformed into a SampleSpectrogram whose .npy file
+contains an (n_mels, time_steps) float32 array. The stage is deterministic
+(_is_deterministic = True) so output_seed is always 0 and _get_applied_values
+returns an empty dict.
+
+The mel spectrogram computation (librosa) is offloaded to a thread pool
+executor so the asyncio event loop is not blocked by CPU-bound work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, ClassVar
+
+import numpy as np
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.core.modifier_stage import ModifierStage
+from pipeline.core.randomization import VariationGenerator
+from pipeline.core.sample import AudioSample, SampleSpectrogram
+from pipeline.io.audio_io import AudioReader
+from pipeline.stages import conventions
+
+
+class SpectrogramStage(ModifierStage[AudioSample, SampleSpectrogram]):
+    """Deterministic stage that converts WAV files to log-mel spectrogram .npy files.
+
+    Output shape: (n_mels, time_steps). Short spectrograms are zero-padded on
+    the right; long spectrograms are truncated from the right.
+
+    input_dir is the directory containing the WAV files referenced by
+    AudioSample.path — typically the output directory of the preceding stage.
+    """
+
+    _is_deterministic: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        output_dir: Path,
+        manifest_store: ManifestStore,
+        n_mels: int,
+        time_steps: int,
+        audio_reader: AudioReader,
+        input_dir: Path,
+    ) -> None:
+        super().__init__(output_dir, manifest_store)
+        self._n_mels = n_mels
+        self._time_steps = time_steps
+        self._audio_reader = audio_reader
+        self._input_dir = input_dir
+
+    def _get_applied_values(
+        self, sample: AudioSample, generator: VariationGenerator
+    ) -> dict[str, Any]:
+        return {}
+
+    def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
+        return input_sample.id
+
+    async def _generate_output(
+        self,
+        input_sample: AudioSample,
+        output_id: str,
+        output_seed: int,
+        applied_values: dict[str, Any],
+        parent_content_hash: str,
+    ) -> SampleSpectrogram:
+        input_path = self._input_dir / input_sample.path
+        audio = await self._audio_reader.read(input_path)
+
+        loop = asyncio.get_running_loop()
+        log_s = await loop.run_in_executor(
+            None,
+            lambda: self._compute_spectrogram(audio.samples, audio.sample_rate),
+        )
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = conventions.sample_file_path(self._output_dir, output_id, "npy")
+        await loop.run_in_executor(None, lambda: np.save(str(output_path), log_s))
+
+        content_hash = self._compute_content_hash(parent_content_hash, output_seed, applied_values)
+
+        return SampleSpectrogram(
+            id=output_id,
+            seed=output_seed,
+            content_hash=content_hash,
+            path=Path(f"{output_id}.npy"),
+            parent_content_hash=parent_content_hash,
+            transcript=input_sample.transcript,
+            parent_id=input_sample.id,
+        )
+
+    def _compute_spectrogram(self, samples: np.ndarray, sample_rate: int) -> np.ndarray:
+        """Compute log-mel spectrogram; pad or truncate to (n_mels, time_steps)."""
+        import librosa  # deferred: unit tests without librosa can import module
+
+        s = librosa.feature.melspectrogram(y=samples, sr=sample_rate, n_mels=self._n_mels)
+        log_s = librosa.power_to_db(s, ref=np.max)
+
+        if log_s.shape[1] < self._time_steps:
+            pad_width = self._time_steps - log_s.shape[1]
+            log_s = np.pad(log_s, ((0, 0), (0, pad_width)), mode="constant")
+        else:
+            log_s = log_s[:, : self._time_steps]
+
+        return log_s

--- a/ml/pipeline/speech/spectrogram_stage.py
+++ b/ml/pipeline/speech/spectrogram_stage.py
@@ -106,4 +106,4 @@ class SpectrogramStage(ModifierStage[AudioSample, SampleSpectrogram]):
         else:
             log_s = log_s[:, : self._time_steps]
 
-        return log_s
+        return log_s.astype(np.float32)

--- a/ml/pipeline/speech/token_stage.py
+++ b/ml/pipeline/speech/token_stage.py
@@ -1,0 +1,113 @@
+"""TokenStage: convert AudioSample transcripts to phoneme token sequences.
+
+Each AudioSample is transformed into a SampleTokens whose .json file contains
+{"phonemes": [...], "tokens": [...]} padded or truncated to input_token_length.
+
+The stage is deterministic (_is_deterministic = True) so output_seed is always
+0 and _get_applied_values returns an empty dict.
+
+Token lookup for missing words follows the skip-on-missing behaviour from the
+legacy script: words absent from VocabResult.words_to_phonemes are silently
+skipped (no error, no contribution to the phoneme sequence).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.core.modifier_stage import ModifierStage
+from pipeline.core.randomization import VariationGenerator
+from pipeline.core.sample import AudioSample, SampleTokens
+from pipeline.intent.vocab_computer import VocabResult
+from pipeline.stages import conventions
+
+
+class TokenStage(ModifierStage[AudioSample, SampleTokens]):
+    """Deterministic stage that converts transcripts to padded phoneme token sequences.
+
+    Output: {id}.json with {"phonemes": [...], "tokens": [...]} where tokens is
+    exactly input_token_length long (padded with ctc_blank_idx or truncated).
+
+    A phoneme_to_idx dict is built at construction time from VocabResult.phoneme_list
+    for O(1) per-phoneme lookup.
+
+    Words absent from VocabResult.words_to_phonemes are silently skipped.
+    """
+
+    _is_deterministic: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        output_dir: Path,
+        manifest_store: ManifestStore,
+        vocab: VocabResult,
+        input_token_length: int,
+    ) -> None:
+        super().__init__(output_dir, manifest_store)
+        self._vocab = vocab
+        self._input_token_length = input_token_length
+        self._phoneme_to_idx: dict[str, int] = {
+            ph: idx for idx, ph in enumerate(vocab.phoneme_list)
+        }
+
+    def _get_applied_values(
+        self, sample: AudioSample, generator: VariationGenerator
+    ) -> dict[str, Any]:
+        return {}
+
+    def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
+        return input_sample.id
+
+    async def _generate_output(
+        self,
+        input_sample: AudioSample,
+        output_id: str,
+        output_seed: int,
+        applied_values: dict[str, Any],
+        parent_content_hash: str,
+    ) -> SampleTokens:
+        phonemes, tokens = self._compute_tokens(input_sample.transcript)
+
+        self._output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = conventions.sample_file_path(self._output_dir, output_id, "json")
+        payload = {"phonemes": phonemes, "tokens": tokens}
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+
+        content_hash = self._compute_content_hash(parent_content_hash, output_seed, applied_values)
+
+        return SampleTokens(
+            id=output_id,
+            seed=output_seed,
+            content_hash=content_hash,
+            path=Path(f"{output_id}.json"),
+            parent_content_hash=parent_content_hash,
+            transcript=input_sample.transcript,
+            parent_id=input_sample.id,
+        )
+
+    def _compute_tokens(self, transcript: str) -> tuple[list[str], list[int]]:
+        """Convert transcript to (phonemes, padded_tokens).
+
+        Words absent from words_to_phonemes are silently skipped.
+        Tokens list is padded to input_token_length with ctc_blank_idx,
+        or truncated from the right if longer.
+        """
+        words = transcript.upper().replace(",", " ").split()
+        phonemes: list[str] = []
+        for word in words:
+            if word in self._vocab.words_to_phonemes:
+                phonemes.extend(self._vocab.words_to_phonemes[word])
+
+        tokens = [self._phoneme_to_idx[ph] for ph in phonemes if ph in self._phoneme_to_idx]
+
+        if len(tokens) < self._input_token_length:
+            pad_count = self._input_token_length - len(tokens)
+            tokens = tokens + [self._vocab.ctc_blank_idx] * pad_count
+        else:
+            tokens = tokens[: self._input_token_length]
+
+        return phonemes, tokens

--- a/ml/pipeline/speech/token_stage.py
+++ b/ml/pipeline/speech/token_stage.py
@@ -3,8 +3,11 @@
 Each AudioSample is transformed into a SampleTokens whose .json file contains
 {"phonemes": [...], "tokens": [...]} padded or truncated to input_token_length.
 
-The stage is deterministic (_is_deterministic = True) so output_seed is always
-0 and _get_applied_values returns an empty dict.
+The stage is deterministic (_is_deterministic = True) so output_seed is always 0.
+
+_get_applied_values returns {"input_token_length": ..., "phoneme_list": [...]} so
+that changing token length or vocab between runs changes the content_hash and
+triggers regen of any previously-cached outputs that used different configuration.
 
 Token lookup for missing words follows the skip-on-missing behaviour from the
 legacy script: words absent from VocabResult.words_to_phonemes are silently
@@ -35,6 +38,9 @@ class TokenStage(ModifierStage[AudioSample, SampleTokens]):
     A phoneme_to_idx dict is built at construction time from VocabResult.phoneme_list
     for O(1) per-phoneme lookup.
 
+    _get_applied_values includes input_token_length and phoneme_list so that changes
+    to either invalidate previously-cached outputs via content_hash comparison.
+
     Words absent from VocabResult.words_to_phonemes are silently skipped.
     """
 
@@ -57,7 +63,10 @@ class TokenStage(ModifierStage[AudioSample, SampleTokens]):
     def _get_applied_values(
         self, sample: AudioSample, generator: VariationGenerator
     ) -> dict[str, Any]:
-        return {}
+        return {
+            "input_token_length": self._input_token_length,
+            "phoneme_list": self._vocab.phoneme_list,
+        }
 
     def _derive_id(self, input_sample: AudioSample, applied_values: dict[str, Any]) -> str:
         return input_sample.id

--- a/ml/pipeline/speech/token_stage.py
+++ b/ml/pipeline/speech/token_stage.py
@@ -13,6 +13,7 @@ skipped (no error, no contribution to the phoneme sequence).
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any, ClassVar
@@ -71,11 +72,14 @@ class TokenStage(ModifierStage[AudioSample, SampleTokens]):
     ) -> SampleTokens:
         phonemes, tokens = self._compute_tokens(input_sample.transcript)
 
+        loop = asyncio.get_running_loop()
         self._output_dir.mkdir(parents=True, exist_ok=True)
         output_path = conventions.sample_file_path(self._output_dir, output_id, "json")
         payload = {"phonemes": phonemes, "tokens": tokens}
-        with open(output_path, "w", encoding="utf-8") as f:
-            json.dump(payload, f)
+        await loop.run_in_executor(
+            None,
+            lambda: output_path.write_text(json.dumps(payload), encoding="utf-8"),
+        )
 
         content_hash = self._compute_content_hash(parent_content_hash, output_seed, applied_values)
 

--- a/ml/pipeline/stages/params.py
+++ b/ml/pipeline/stages/params.py
@@ -52,6 +52,24 @@ class AddMicNoiseParams:
 
 
 @dataclass
+class ComputeSpectrogramsParams:
+    n_mels: int
+    time_steps: int
+
+
+@dataclass
+class ComputeTokensParams:
+    input_token_length: int
+
+
+@dataclass
+class CreateSetManifestsParams:
+    train_pct: int
+    val_pct: int
+    test_pct: int
+
+
+@dataclass
 class PipelineParams:
     variations_per_phrase: int
     subsample_rate: int
@@ -61,6 +79,9 @@ class PipelineParams:
     add_delays: AddDelaysParams
     add_background_noise: AddBackgroundNoiseParams
     add_mic_noise: AddMicNoiseParams
+    compute_spectrograms: ComputeSpectrogramsParams
+    compute_tokens: ComputeTokensParams
+    create_set_manifests: CreateSetManifestsParams
 
     @classmethod
     def load(cls, path: Path) -> "PipelineParams":
@@ -73,6 +94,9 @@ class PipelineParams:
         stage_delays = raw["stages"]["add_delays"]
         stage_bg_noise = raw["stages"]["add_background_noise"]
         stage_mic_noise = raw["stages"]["add_mic_noise"]
+        stage_spectrograms = raw["stages"]["compute_spectrograms"]
+        stage_tokens = raw["stages"]["compute_tokens"]
+        stage_set_manifests = raw["stages"]["create_set_manifests"]
 
         return cls(
             variations_per_phrase=int(pipeline["variations_per_phrase"]),
@@ -106,5 +130,17 @@ class PipelineParams:
                 vary_probability=float(stage_mic_noise["vary_probability"]),
                 amplitude_min=float(stage_mic_noise["amplitude_min"]),
                 amplitude_max=float(stage_mic_noise["amplitude_max"]),
+            ),
+            compute_spectrograms=ComputeSpectrogramsParams(
+                n_mels=int(stage_spectrograms["n_mels"]),
+                time_steps=int(stage_spectrograms["time_steps"]),
+            ),
+            compute_tokens=ComputeTokensParams(
+                input_token_length=int(stage_tokens["input_token_length"]),
+            ),
+            create_set_manifests=CreateSetManifestsParams(
+                train_pct=int(stage_set_manifests["train_pct"]),
+                val_pct=int(stage_set_manifests["val_pct"]),
+                test_pct=int(stage_set_manifests["test_pct"]),
             ),
         )

--- a/ml/pipeline/stages/speech_07_compute_tokens.py
+++ b/ml/pipeline/stages/speech_07_compute_tokens.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.intent.vocab_computer import VocabResult
+from pipeline.speech.token_stage import TokenStage
+from pipeline.stages import conventions
+from pipeline.stages.params import PipelineParams
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def _load_vocab(vocab_dir: Path) -> VocabResult:
+    """Reconstruct VocabResult from phoneme_list.txt and words_to_phonemes.json."""
+    phoneme_list = (vocab_dir / "phoneme_list.txt").read_text(encoding="utf-8").splitlines()
+    with open(vocab_dir / "words_to_phonemes.json", encoding="utf-8") as f:
+        words_to_phonemes: dict[str, list[str]] = json.load(f)
+    ctc_blank_idx = len(phoneme_list)
+    return VocabResult(
+        phoneme_list=phoneme_list,
+        words_to_phonemes=words_to_phonemes,
+        ctc_blank_idx=ctc_blank_idx,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert AudioSample transcripts to phoneme token sequences"
+    )
+    parser.add_argument("--input-manifest-dir", required=True, type=Path)
+    parser.add_argument("--vocab-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    params = PipelineParams.load(conventions.params_path(_PROJECT_ROOT))
+
+    store = ManifestStore()
+    input_manifest = store.read(conventions.manifest_path(args.input_manifest_dir))
+
+    vocab = _load_vocab(args.vocab_dir)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    stage = TokenStage(
+        output_dir=args.output_dir,
+        manifest_store=store,
+        vocab=vocab,
+        input_token_length=params.compute_tokens.input_token_length,
+    )
+
+    asyncio.run(
+        stage.transform(
+            input_manifest,
+            conventions.manifest_path(args.output_dir),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/pipeline/stages/speech_08_compute_spectrograms.py
+++ b/ml/pipeline/stages/speech_08_compute_spectrograms.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.io.audio_io import LibrosaAudioReader
+from pipeline.speech.spectrogram_stage import SpectrogramStage
+from pipeline.stages import conventions
+from pipeline.stages.params import PipelineParams
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute log-mel spectrograms for WAV audio samples"
+    )
+    parser.add_argument("--input-manifest-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    params = PipelineParams.load(conventions.params_path(_PROJECT_ROOT))
+
+    store = ManifestStore()
+    input_manifest = store.read(conventions.manifest_path(args.input_manifest_dir))
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    stage = SpectrogramStage(
+        output_dir=args.output_dir,
+        manifest_store=store,
+        n_mels=params.compute_spectrograms.n_mels,
+        time_steps=params.compute_spectrograms.time_steps,
+        audio_reader=LibrosaAudioReader(),
+        input_dir=args.input_manifest_dir,
+    )
+
+    asyncio.run(
+        stage.transform(
+            input_manifest,
+            conventions.manifest_path(args.output_dir),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/pipeline/stages/speech_09_create_set_manifests.py
+++ b/ml/pipeline/stages/speech_09_create_set_manifests.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from pipeline.core.manifest import ManifestStore
+from pipeline.speech.set_splitter import SetManifestSplitter
+from pipeline.stages import conventions
+from pipeline.stages.params import PipelineParams
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Split fully-augmented manifest into train/val/test subsets"
+    )
+    parser.add_argument("--input-manifest-dir", required=True, type=Path)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    args = parser.parse_args()
+
+    params = PipelineParams.load(conventions.params_path(_PROJECT_ROOT))
+
+    store = ManifestStore()
+    input_manifest = store.read(conventions.manifest_path(args.input_manifest_dir))
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    splitter = SetManifestSplitter(seed=42)
+    splitter.split(
+        input_manifest,
+        train_pct=params.create_set_manifests.train_pct,
+        val_pct=params.create_set_manifests.val_pct,
+        test_pct=params.create_set_manifests.test_pct,
+        output_dir=args.output_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/test/pipeline/speech/test_set_splitter.py
+++ b/ml/test/pipeline/speech/test_set_splitter.py
@@ -1,0 +1,245 @@
+"""Unit tests for SetManifestSplitter."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.sample import AudioSample
+from pipeline.speech.set_splitter import SetManifestSplitter
+from pipeline.stages import conventions
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio_sample(sample_id: str, transcript: str = "TV_ON") -> AudioSample:
+    content = f"{sample_id}:audio"
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return AudioSample(
+        id=sample_id,
+        seed=0,
+        content_hash=content_hash,
+        path=Path(f"{sample_id}.wav"),
+        parent_content_hash="parent_hash",
+        transcript=transcript,
+        applied_values={},
+    )
+
+
+def _make_manifest(count: int, prefix: str = "sample") -> Manifest[AudioSample]:
+    samples = [_make_audio_sample(f"{prefix}_{i:03d}") for i in range(count)]
+    return Manifest(samples)
+
+
+def _make_splitter(seed: int = 42) -> SetManifestSplitter:
+    return SetManifestSplitter(seed=seed)
+
+
+# ---------------------------------------------------------------------------
+# TestValidation
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_percentages_not_summing_to_100_raises_value_error(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        with pytest.raises(ValueError):
+            splitter.split(manifest, train_pct=50, val_pct=20, test_pct=20, output_dir=tmp_path)
+
+    def test_percentages_summing_to_100_does_not_raise(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        # Should not raise
+        splitter.split(manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path)
+
+    def test_all_zeros_raises_value_error(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        with pytest.raises(ValueError):
+            splitter.split(manifest, train_pct=0, val_pct=0, test_pct=0, output_dir=tmp_path)
+
+    def test_sum_of_101_raises_value_error(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        with pytest.raises(ValueError):
+            splitter.split(manifest, train_pct=70, val_pct=20, test_pct=11, output_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# TestSplitCounts
+# ---------------------------------------------------------------------------
+
+
+class TestSplitCounts:
+    def test_total_count_equals_input_count(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(100)
+        train, val, test = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        assert len(train.samples) + len(val.samples) + len(test.samples) == 100
+
+    def test_split_counts_match_percentages(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(100)
+        train, val, test = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        assert len(train.samples) == 70
+        assert len(val.samples) == 20
+        assert len(test.samples) == 10
+
+    def test_split_with_different_percentages(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(100)
+        train, val, test = splitter.split(
+            manifest, train_pct=80, val_pct=10, test_pct=10, output_dir=tmp_path
+        )
+        assert len(train.samples) == 80
+        assert len(val.samples) == 10
+        assert len(test.samples) == 10
+
+    def test_split_small_manifest(self, tmp_path: Path) -> None:
+        """With 10 samples at 70/20/10, counts are 7/2/1."""
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        train, val, test = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        assert len(train.samples) + len(val.samples) + len(test.samples) == 10
+
+
+# ---------------------------------------------------------------------------
+# TestIdPreservation
+# ---------------------------------------------------------------------------
+
+
+class TestIdPreservation:
+    def test_all_input_ids_appear_in_exactly_one_split(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(100)
+        input_ids = {s.id for s in manifest.samples}
+        train, val, test = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        train_ids = {s.id for s in train.samples}
+        val_ids = {s.id for s in val.samples}
+        test_ids = {s.id for s in test.samples}
+
+        # No duplicates across splits
+        assert len(train_ids & val_ids) == 0
+        assert len(train_ids & test_ids) == 0
+        assert len(val_ids & test_ids) == 0
+
+        # All input IDs accounted for
+        assert train_ids | val_ids | test_ids == input_ids
+
+    def test_sample_ids_unchanged_in_splits(self, tmp_path: Path) -> None:
+        """Sample id values are preserved from input — not reassigned."""
+        splitter = _make_splitter()
+        manifest = _make_manifest(30)
+        input_ids = {s.id for s in manifest.samples}
+        train, val, test = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        all_output_ids = (
+            {s.id for s in train.samples}
+            | {s.id for s in val.samples}
+            | {s.id for s in test.samples}
+        )
+        assert all_output_ids == input_ids
+
+
+# ---------------------------------------------------------------------------
+# TestOutputFiles
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFiles:
+    def test_writes_train_manifest_json(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        splitter.split(manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path)
+        assert (tmp_path / "train_manifest.json").exists()
+
+    def test_writes_val_manifest_json(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        splitter.split(manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path)
+        assert (tmp_path / "val_manifest.json").exists()
+
+    def test_writes_test_manifest_json(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        splitter.split(manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path)
+        assert (tmp_path / "test_manifest.json").exists()
+
+    def test_output_files_use_conventions_split_manifest_path(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        splitter.split(manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path)
+        # Confirm these match what conventions.split_manifest_path returns
+        assert (conventions.split_manifest_path(tmp_path, "train")).exists()
+        assert (conventions.split_manifest_path(tmp_path, "val")).exists()
+        assert (conventions.split_manifest_path(tmp_path, "test")).exists()
+
+    def test_split_returns_manifest_tuple(self, tmp_path: Path) -> None:
+        splitter = _make_splitter()
+        manifest = _make_manifest(10)
+        result = splitter.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# TestDeterminism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_same_seed_produces_same_splits(self, tmp_path: Path) -> None:
+        """Two splitters with the same seed produce identical splits."""
+        manifest = _make_manifest(50)
+
+        splitter1 = SetManifestSplitter(seed=42)
+        train1, val1, test1 = splitter1.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path / "run1"
+        )
+
+        splitter2 = SetManifestSplitter(seed=42)
+        train2, val2, test2 = splitter2.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path / "run2"
+        )
+
+        assert [s.id for s in train1.samples] == [s.id for s in train2.samples]
+        assert [s.id for s in val1.samples] == [s.id for s in val2.samples]
+        assert [s.id for s in test1.samples] == [s.id for s in test2.samples]
+
+    def test_different_seeds_produce_different_splits(self, tmp_path: Path) -> None:
+        """Different seeds should produce different orderings."""
+        manifest = _make_manifest(50)
+
+        splitter1 = SetManifestSplitter(seed=42)
+        train1, _, _ = splitter1.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path / "run1"
+        )
+
+        splitter2 = SetManifestSplitter(seed=99)
+        train2, _, _ = splitter2.split(
+            manifest, train_pct=70, val_pct=20, test_pct=10, output_dir=tmp_path / "run2"
+        )
+
+        # With 50 samples and different seeds, orderings almost certainly differ
+        assert [s.id for s in train1.samples] != [s.id for s in train2.samples]

--- a/ml/test/pipeline/speech/test_spectrogram_stage.py
+++ b/ml/test/pipeline/speech/test_spectrogram_stage.py
@@ -122,13 +122,29 @@ class TestDeriveId:
 
 
 class TestGetAppliedValues:
-    def test_get_applied_values_returns_empty_dict(self, tmp_path: Path) -> None:
+    def test_get_applied_values_includes_n_mels(self, tmp_path: Path) -> None:
         from pipeline.core.randomization import VariationGenerator
 
-        stage, _ = _make_stage(tmp_path)
+        stage, _ = _make_stage(tmp_path, n_mels=40, time_steps=32)
         sample = _make_audio_sample()
         result = stage._get_applied_values(sample, VariationGenerator(0))
-        assert result == {}
+        assert result["n_mels"] == 40
+
+    def test_get_applied_values_includes_time_steps(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        stage, _ = _make_stage(tmp_path, n_mels=40, time_steps=32)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result["time_steps"] == 32
+
+    def test_get_applied_values_reflects_different_n_mels(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        stage, _ = _make_stage(tmp_path, n_mels=80, time_steps=32)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result["n_mels"] == 80
 
 
 # ---------------------------------------------------------------------------
@@ -238,3 +254,27 @@ class TestSkipPath:
         result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         assert result2.samples[0].parent_id == result1.samples[0].parent_id
+
+    def test_changing_n_mels_triggers_regen(self, tmp_path: Path) -> None:
+        """When n_mels changes between runs, audio reader is called again (regen path)."""
+        reader = _RecordingAudioReader()
+        stage1, _ = _make_stage(tmp_path, n_mels=8, time_steps=16, audio_reader=reader)
+        sample = _make_audio_sample()
+        asyncio.run(stage1.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1
+
+        stage2, _ = _make_stage(tmp_path, n_mels=16, time_steps=16, audio_reader=reader)
+        asyncio.run(stage2.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 2  # regen triggered by n_mels change
+
+    def test_changing_time_steps_triggers_regen(self, tmp_path: Path) -> None:
+        """When time_steps changes between runs, audio reader is called again (regen path)."""
+        reader = _RecordingAudioReader()
+        stage1, _ = _make_stage(tmp_path, n_mels=8, time_steps=16, audio_reader=reader)
+        sample = _make_audio_sample()
+        asyncio.run(stage1.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1
+
+        stage2, _ = _make_stage(tmp_path, n_mels=8, time_steps=32, audio_reader=reader)
+        asyncio.run(stage2.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 2  # regen triggered by time_steps change

--- a/ml/test/pipeline/speech/test_spectrogram_stage.py
+++ b/ml/test/pipeline/speech/test_spectrogram_stage.py
@@ -170,6 +170,17 @@ class TestGenerateOutput:
         data = np.load(str(npy_path))
         assert data.shape == (n_mels, time_steps)
 
+    def test_output_npy_dtype_is_float32(self, tmp_path: Path) -> None:
+        """Spectrogram array is saved as float32 regardless of librosa output dtype."""
+        n_mels = 8
+        time_steps = 16
+        stage, _ = _make_stage(tmp_path, n_mels=n_mels, time_steps=time_steps)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        npy_path = tmp_path / "TV_ON_Jenny_r100.npy"
+        data = np.load(str(npy_path))
+        assert data.dtype == np.float32
+
     def test_output_file_has_npy_extension(self, tmp_path: Path) -> None:
         stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
         sample = _make_audio_sample(sample_id="MY_SAMPLE")

--- a/ml/test/pipeline/speech/test_spectrogram_stage.py
+++ b/ml/test/pipeline/speech/test_spectrogram_stage.py
@@ -1,0 +1,229 @@
+"""Unit tests for SpectrogramStage."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.sample import AudioSample
+from pipeline.io.audio_io import AudioData
+from pipeline.speech.spectrogram_stage import SpectrogramStage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio_sample(
+    sample_id: str = "TV_ON_Jenny_r100",
+    transcript: str = "TV_ON",
+) -> AudioSample:
+    content = f"{sample_id}:audio"
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return AudioSample(
+        id=sample_id,
+        seed=0,
+        content_hash=content_hash,
+        path=Path(f"{sample_id}.wav"),
+        parent_content_hash="parent_hash",
+        transcript=transcript,
+        applied_values={},
+    )
+
+
+class _RecordingAudioReader:
+    """Stub AudioReader that records read() calls and returns silence."""
+
+    def __init__(self, n_mels: int = 40, sample_rate: int = 16000, duration_s: float = 0.5) -> None:
+        self.calls: list[Path] = []
+        self._sample_rate = sample_rate
+        self._duration_s = duration_s
+
+    async def read(self, path: Path) -> AudioData:
+        self.calls.append(path)
+        n_samples = int(self._sample_rate * self._duration_s)
+        samples = np.zeros(n_samples, dtype=np.float32)
+        return AudioData(samples=samples, sample_rate=self._sample_rate)
+
+
+def _make_stage(
+    output_dir: Path,
+    *,
+    n_mels: int = 40,
+    time_steps: int = 32,
+    audio_reader: _RecordingAudioReader | None = None,
+    input_dir: Path | None = None,
+) -> tuple[SpectrogramStage, _RecordingAudioReader]:
+    if audio_reader is None:
+        audio_reader = _RecordingAudioReader(n_mels=n_mels)
+    if input_dir is None:
+        input_dir = output_dir
+    stage = SpectrogramStage(
+        output_dir=output_dir,
+        manifest_store=ManifestStore(),
+        n_mels=n_mels,
+        time_steps=time_steps,
+        audio_reader=audio_reader,
+        input_dir=input_dir,
+    )
+    return stage, audio_reader
+
+
+# ---------------------------------------------------------------------------
+# TestIsDeterministic
+# ---------------------------------------------------------------------------
+
+
+class TestIsDeterministic:
+    def test_is_deterministic_class_var_is_true(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path)
+        assert stage._is_deterministic is True
+
+    def test_is_deterministic_is_class_variable(self) -> None:
+        assert SpectrogramStage._is_deterministic is True
+
+
+# ---------------------------------------------------------------------------
+# TestDeriveId
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveId:
+    def test_derive_id_returns_input_sample_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {})
+        assert result == "TV_ON_Jenny_r100"
+
+    def test_derive_id_returns_input_sample_id_different_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="VOLUME_UP_Aria_r110")
+        result = stage._derive_id(sample, {})
+        assert result == "VOLUME_UP_Aria_r110"
+
+    def test_derive_id_ignores_applied_values(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = stage._derive_id(sample, {"some_key": "some_value"})
+        assert result == "MY_SAMPLE"
+
+
+# ---------------------------------------------------------------------------
+# TestGetAppliedValues
+# ---------------------------------------------------------------------------
+
+
+class TestGetAppliedValues:
+    def test_get_applied_values_returns_empty_dict(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        stage, _ = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateOutput
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOutput:
+    def test_parent_id_equals_input_sample_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].parent_id == "TV_ON_Jenny_r100"
+
+    def test_parent_id_equals_input_sample_id_different_sample(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="MUTE_Bob_r95")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].parent_id == "MUTE_Bob_r95"
+
+    def test_output_npy_shape_is_n_mels_by_time_steps(self, tmp_path: Path) -> None:
+        n_mels = 8
+        time_steps = 16
+        stage, _ = _make_stage(tmp_path, n_mels=n_mels, time_steps=time_steps)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        npy_path = tmp_path / "TV_ON_Jenny_r100.npy"
+        assert npy_path.exists()
+        data = np.load(str(npy_path))
+        assert data.shape == (n_mels, time_steps)
+
+    def test_output_npy_shape_with_different_dimensions(self, tmp_path: Path) -> None:
+        n_mels = 20
+        time_steps = 32
+        stage, _ = _make_stage(tmp_path, n_mels=n_mels, time_steps=time_steps)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        npy_path = tmp_path / "TV_ON_Jenny_r100.npy"
+        data = np.load(str(npy_path))
+        assert data.shape == (n_mels, time_steps)
+
+    def test_output_file_has_npy_extension(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].path == Path("MY_SAMPLE.npy")
+
+    def test_output_calls_audio_reader(self, tmp_path: Path) -> None:
+        stage, reader = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample()
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1
+
+    def test_output_sample_id_equals_input_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].id == "TV_ON_Jenny_r100"
+
+    def test_transcript_preserved(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(transcript="CHANNEL_UP")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].transcript == "CHANNEL_UP"
+
+
+# ---------------------------------------------------------------------------
+# TestSkipPath
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPath:
+    def test_skip_path_does_not_call_reader_on_second_run(self, tmp_path: Path) -> None:
+        """Second transform() call does not read audio again (skip-unchanged)."""
+        stage, reader = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample()
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert len(reader.calls) == 1  # No additional call
+
+    def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].id == result1.samples[0].id
+
+    def test_skip_path_preserves_parent_id(self, tmp_path: Path) -> None:
+        stage, _ = _make_stage(tmp_path, n_mels=8, time_steps=16)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].parent_id == result1.samples[0].parent_id

--- a/ml/test/pipeline/speech/test_token_stage.py
+++ b/ml/test/pipeline/speech/test_token_stage.py
@@ -1,0 +1,300 @@
+"""Unit tests for TokenStage."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from pipeline.core.manifest import Manifest, ManifestStore
+from pipeline.core.sample import AudioSample
+from pipeline.intent.vocab_computer import VocabResult
+from pipeline.speech.token_stage import TokenStage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_audio_sample(
+    sample_id: str = "TV_ON_Jenny_r100",
+    transcript: str = "TV_ON",
+) -> AudioSample:
+    content = f"{sample_id}:audio"
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return AudioSample(
+        id=sample_id,
+        seed=0,
+        content_hash=content_hash,
+        path=Path(f"{sample_id}.wav"),
+        parent_content_hash="parent_hash",
+        transcript=transcript,
+        applied_values={},
+    )
+
+
+def _make_vocab(
+    phoneme_list: list[str] | None = None,
+    words_to_phonemes: dict[str, list[str]] | None = None,
+) -> VocabResult:
+    if phoneme_list is None:
+        phoneme_list = ["AA", "EH", "IH", "OW", "UH"]
+    if words_to_phonemes is None:
+        # TV_ON => T V AX N, mapped to phonemes in phoneme_list
+        words_to_phonemes = {
+            "TV_ON": ["AA", "EH"],
+            "MUTE": ["IH", "OW"],
+        }
+    return VocabResult(
+        phoneme_list=phoneme_list,
+        words_to_phonemes=words_to_phonemes,
+        ctc_blank_idx=len(phoneme_list),
+    )
+
+
+def _make_stage(
+    output_dir: Path,
+    *,
+    vocab: VocabResult | None = None,
+    input_token_length: int = 10,
+) -> TokenStage:
+    if vocab is None:
+        vocab = _make_vocab()
+    return TokenStage(
+        output_dir=output_dir,
+        manifest_store=ManifestStore(),
+        vocab=vocab,
+        input_token_length=input_token_length,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestIsDeterministic
+# ---------------------------------------------------------------------------
+
+
+class TestIsDeterministic:
+    def test_is_deterministic_class_var_is_true(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        assert stage._is_deterministic is True
+
+    def test_is_deterministic_is_class_variable(self) -> None:
+        assert TokenStage._is_deterministic is True
+
+
+# ---------------------------------------------------------------------------
+# TestDeriveId
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveId:
+    def test_derive_id_returns_input_sample_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = stage._derive_id(sample, {})
+        assert result == "TV_ON_Jenny_r100"
+
+    def test_derive_id_returns_input_sample_id_different_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="MUTE_Bob_r95")
+        result = stage._derive_id(sample, {})
+        assert result == "MUTE_Bob_r95"
+
+    def test_derive_id_ignores_applied_values(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = stage._derive_id(sample, {"some_key": "some_value"})
+        assert result == "MY_SAMPLE"
+
+
+# ---------------------------------------------------------------------------
+# TestGetAppliedValues
+# ---------------------------------------------------------------------------
+
+
+class TestGetAppliedValues:
+    def test_get_applied_values_returns_empty_dict(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateOutput
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateOutput:
+    def test_parent_id_equals_input_sample_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100", transcript="TV_ON")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].parent_id == "TV_ON_Jenny_r100"
+
+    def test_parent_id_equals_input_sample_id_different_sample(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="MUTE_Bob_r95", transcript="MUTE")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].parent_id == "MUTE_Bob_r95"
+
+    def test_output_json_has_phonemes_key(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path, input_token_length=10)
+        sample = _make_audio_sample(transcript="TV_ON")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        assert json_path.exists()
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert "phonemes" in data
+
+    def test_output_json_has_tokens_key(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path, input_token_length=10)
+        sample = _make_audio_sample(transcript="TV_ON")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert "tokens" in data
+
+    def test_tokens_padded_to_input_token_length(self, tmp_path: Path) -> None:
+        """Tokens list is exactly input_token_length long."""
+        input_token_length = 10
+        stage = _make_stage(tmp_path, input_token_length=input_token_length)
+        sample = _make_audio_sample(transcript="TV_ON")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert len(data["tokens"]) == input_token_length
+
+    def test_tokens_truncated_to_input_token_length(self, tmp_path: Path) -> None:
+        """When phonemes exceed input_token_length, tokens are truncated to length."""
+        phoneme_list = ["A", "B", "C", "D", "E", "F", "G", "H"]
+        words_to_phonemes = {"LONG": ["A", "B", "C", "D", "E", "F", "G", "H"]}
+        vocab = VocabResult(
+            phoneme_list=phoneme_list,
+            words_to_phonemes=words_to_phonemes,
+            ctc_blank_idx=len(phoneme_list),
+        )
+        input_token_length = 4
+        stage = TokenStage(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            vocab=vocab,
+            input_token_length=input_token_length,
+        )
+        sample = _make_audio_sample(sample_id="LONG_Jenny_r100", transcript="LONG")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "LONG_Jenny_r100.json"
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert len(data["tokens"]) == input_token_length
+
+    def test_tokens_padding_uses_ctc_blank_idx(self, tmp_path: Path) -> None:
+        """Padding tokens use ctc_blank_idx (= len(phoneme_list))."""
+        phoneme_list = ["AA", "EH"]
+        words_to_phonemes = {"TV_ON": ["AA"]}  # Only 1 phoneme
+        vocab = VocabResult(
+            phoneme_list=phoneme_list,
+            words_to_phonemes=words_to_phonemes,
+            ctc_blank_idx=len(phoneme_list),
+        )
+        input_token_length = 5
+        stage = TokenStage(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            vocab=vocab,
+            input_token_length=input_token_length,
+        )
+        sample = _make_audio_sample(transcript="TV_ON")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        # Token 0 = index of "AA" = 0; tokens 1..4 = ctc_blank_idx = 2
+        assert data["tokens"][0] == 0
+        assert data["tokens"][1:] == [2, 2, 2, 2]
+
+    def test_missing_word_is_skipped(self, tmp_path: Path) -> None:
+        """Words absent from words_to_phonemes are silently skipped."""
+        phoneme_list = ["AA", "EH"]
+        words_to_phonemes = {"KNOWN": ["AA"]}
+        vocab = VocabResult(
+            phoneme_list=phoneme_list,
+            words_to_phonemes=words_to_phonemes,
+            ctc_blank_idx=len(phoneme_list),
+        )
+        input_token_length = 5
+        stage = TokenStage(
+            output_dir=tmp_path,
+            manifest_store=ManifestStore(),
+            vocab=vocab,
+            input_token_length=input_token_length,
+        )
+        # UNKNOWN not in words_to_phonemes — should be skipped
+        sample = _make_audio_sample(transcript="UNKNOWN KNOWN")
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        # Only "KNOWN" contributes 1 phoneme ("AA" = index 0); rest padded
+        assert data["tokens"][0] == 0
+        assert data["tokens"][1:] == [2, 2, 2, 2]
+
+    def test_output_sample_id_equals_input_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="TV_ON_Jenny_r100")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].id == "TV_ON_Jenny_r100"
+
+    def test_transcript_preserved(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(transcript="CHANNEL_UP")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].transcript == "CHANNEL_UP"
+
+    def test_output_file_has_json_extension(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE")
+        result = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result.samples[0].path == Path("MY_SAMPLE.json")
+
+
+# ---------------------------------------------------------------------------
+# TestSkipPath
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPath:
+    def test_skip_path_does_not_write_json_on_second_run(self, tmp_path: Path) -> None:
+        """Second transform() call does not regenerate JSON (skip-unchanged)."""
+        stage = _make_stage(tmp_path, input_token_length=10)
+        sample = _make_audio_sample(transcript="TV_ON")
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        # Record mtime after first run
+        mtime_after_first = json_path.stat().st_mtime
+
+        asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        mtime_after_second = json_path.stat().st_mtime
+        # File should not have been rewritten
+        assert mtime_after_second == mtime_after_first
+
+    def test_skip_path_preserves_output_sample_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path, input_token_length=10)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE", transcript="TV_ON")
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].id == result1.samples[0].id
+
+    def test_skip_path_preserves_parent_id(self, tmp_path: Path) -> None:
+        stage = _make_stage(tmp_path, input_token_length=10)
+        sample = _make_audio_sample(sample_id="MY_SAMPLE", transcript="TV_ON")
+
+        result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        assert result2.samples[0].parent_id == result1.samples[0].parent_id

--- a/ml/test/pipeline/speech/test_token_stage.py
+++ b/ml/test/pipeline/speech/test_token_stage.py
@@ -118,13 +118,31 @@ class TestDeriveId:
 
 
 class TestGetAppliedValues:
-    def test_get_applied_values_returns_empty_dict(self, tmp_path: Path) -> None:
+    def test_get_applied_values_includes_input_token_length(self, tmp_path: Path) -> None:
         from pipeline.core.randomization import VariationGenerator
 
-        stage = _make_stage(tmp_path)
+        stage = _make_stage(tmp_path, input_token_length=10)
         sample = _make_audio_sample()
         result = stage._get_applied_values(sample, VariationGenerator(0))
-        assert result == {}
+        assert result["input_token_length"] == 10
+
+    def test_get_applied_values_reflects_different_input_token_length(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        stage = _make_stage(tmp_path, input_token_length=20)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result["input_token_length"] == 20
+
+    def test_get_applied_values_includes_phoneme_list(self, tmp_path: Path) -> None:
+        from pipeline.core.randomization import VariationGenerator
+
+        phoneme_list = ["AA", "EH", "IH", "OW", "UH"]
+        vocab = _make_vocab(phoneme_list=phoneme_list)
+        stage = _make_stage(tmp_path, vocab=vocab)
+        sample = _make_audio_sample()
+        result = stage._get_applied_values(sample, VariationGenerator(0))
+        assert result["phoneme_list"] == phoneme_list
 
 
 # ---------------------------------------------------------------------------
@@ -298,3 +316,31 @@ class TestSkipPath:
         result1 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         result2 = asyncio.run(stage.transform(Manifest([sample]), tmp_path / "manifest.json"))
         assert result2.samples[0].parent_id == result1.samples[0].parent_id
+
+    def test_changing_input_token_length_triggers_regen(self, tmp_path: Path) -> None:
+        """When input_token_length changes between runs, output file is rewritten (regen path)."""
+        sample = _make_audio_sample(transcript="TV_ON")
+        stage1 = _make_stage(tmp_path, input_token_length=10)
+        asyncio.run(stage1.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        mtime_after_first = json_path.stat().st_mtime
+
+        stage2 = _make_stage(tmp_path, input_token_length=20)
+        asyncio.run(stage2.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        mtime_after_second = json_path.stat().st_mtime
+        assert mtime_after_second != mtime_after_first  # regen triggered
+
+    def test_changing_phoneme_list_triggers_regen(self, tmp_path: Path) -> None:
+        """When phoneme_list changes between runs, output file is rewritten (regen path)."""
+        sample = _make_audio_sample(transcript="TV_ON")
+        vocab1 = _make_vocab(phoneme_list=["AA", "EH", "IH"])
+        stage1 = _make_stage(tmp_path, vocab=vocab1, input_token_length=10)
+        asyncio.run(stage1.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        json_path = tmp_path / "TV_ON_Jenny_r100.json"
+        mtime_after_first = json_path.stat().st_mtime
+
+        vocab2 = _make_vocab(phoneme_list=["AA", "EH", "IH", "OW"])
+        stage2 = _make_stage(tmp_path, vocab=vocab2, input_token_length=10)
+        asyncio.run(stage2.transform(Manifest([sample]), tmp_path / "manifest.json"))
+        mtime_after_second = json_path.stat().st_mtime
+        assert mtime_after_second != mtime_after_first  # regen triggered

--- a/ml/test/pipeline/stages/test_params.py
+++ b/ml/test/pipeline/stages/test_params.py
@@ -14,6 +14,9 @@ from pipeline.stages.params import (
     AddBackgroundNoiseParams,
     AddDelaysParams,
     AddMicNoiseParams,
+    ComputeSpectrogramsParams,
+    ComputeTokensParams,
+    CreateSetManifestsParams,
     GeneratePhraseParams,
     GenerateSamplesParams,
     PipelineParams,
@@ -61,6 +64,18 @@ _VALID_DATA = {
             "vary_probability": 0.5,
             "amplitude_min": 0.001,
             "amplitude_max": 0.05,
+        },
+        "compute_spectrograms": {
+            "n_mels": 128,
+            "time_steps": 256,
+        },
+        "compute_tokens": {
+            "input_token_length": 50,
+        },
+        "create_set_manifests": {
+            "train_pct": 70,
+            "val_pct": 20,
+            "test_pct": 10,
         },
     },
 }
@@ -250,6 +265,101 @@ class TestAddMicNoiseParamsLoad:
         import copy
         data = copy.deepcopy(_VALID_DATA)
         del data["stages"]["add_mic_noise"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)
+
+
+class TestComputeSpectrogramsParamsLoad:
+    def test_loads_compute_spectrograms_fields(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        cs = params.compute_spectrograms
+        assert cs.n_mels == 128
+        assert cs.time_steps == 256
+
+    def test_compute_spectrograms_is_correct_type(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.compute_spectrograms, ComputeSpectrogramsParams)
+
+    def test_compute_spectrograms_fields_are_ints(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        cs = params.compute_spectrograms
+        assert isinstance(cs.n_mels, int)
+        assert isinstance(cs.time_steps, int)
+
+    def test_missing_compute_spectrograms_stage_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["stages"]["compute_spectrograms"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)
+
+
+class TestComputeTokensParamsLoad:
+    def test_loads_compute_tokens_fields(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        ct = params.compute_tokens
+        assert ct.input_token_length == 50
+
+    def test_compute_tokens_is_correct_type(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.compute_tokens, ComputeTokensParams)
+
+    def test_compute_tokens_field_is_int(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.compute_tokens.input_token_length, int)
+
+    def test_missing_compute_tokens_stage_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["stages"]["compute_tokens"]
+        params_file = _write_params(tmp_path, data)
+        with pytest.raises(KeyError):
+            PipelineParams.load(params_file)
+
+
+class TestCreateSetManifestsParamsLoad:
+    def test_loads_create_set_manifests_fields(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        sm = params.create_set_manifests
+        assert sm.train_pct == 70
+        assert sm.val_pct == 20
+        assert sm.test_pct == 10
+
+    def test_create_set_manifests_is_correct_type(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        assert isinstance(params.create_set_manifests, CreateSetManifestsParams)
+
+    def test_create_set_manifests_fields_are_ints(self, tmp_path: Path) -> None:
+        params_file = _write_params(tmp_path, _VALID_DATA)
+        params = PipelineParams.load(params_file)
+
+        sm = params.create_set_manifests
+        assert isinstance(sm.train_pct, int)
+        assert isinstance(sm.val_pct, int)
+        assert isinstance(sm.test_pct, int)
+
+    def test_missing_create_set_manifests_stage_raises(self, tmp_path: Path) -> None:
+        import copy
+        data = copy.deepcopy(_VALID_DATA)
+        del data["stages"]["create_set_manifests"]
         params_file = _write_params(tmp_path, data)
         with pytest.raises(KeyError):
             PipelineParams.load(params_file)


### PR DESCRIPTION
## Summary

- Add `SpectrogramStage` — deterministic `ModifierStage` that computes log-mel spectrograms via librosa (offloaded to thread pool), pads/truncates to `(n_mels, time_steps)`, and writes `.npy` output
- Add `TokenStage` — deterministic `ModifierStage` that converts transcripts to padded phoneme token sequences using an injected `VocabResult`; silently skips missing words; writes `.json` output
- Add `SetManifestSplitter` — splits the fully-augmented `Manifest[AudioSample]` into train/val/test subsets using `conventions.split_manifest_path`; validates percentages sum to 100
- Add DVC entry-points `speech_07_compute_tokens.py`, `speech_08_compute_spectrograms.py`, `speech_09_create_set_manifests.py`
- Extend `PipelineParams` with `ComputeSpectrogramsParams`, `ComputeTokensParams`, `CreateSetManifestsParams`
- Add 66 unit tests across 4 test files (347 total passing)

## Test plan

- [ ] `SpectrogramStage`: `_is_deterministic` is a class variable set to `True`; `_derive_id` returns `input_sample.id`; `_get_applied_values` returns `{}`; output `.npy` shape is `(n_mels, time_steps)`; `parent_id` equals `input_sample.id`; skip-unchanged path does not call reader on second run
- [ ] `TokenStage`: same determinism checks; output JSON has `phonemes` and `tokens` keys; tokens padded to `input_token_length` using `ctc_blank_idx`; missing words skipped silently; skip-unchanged path works
- [ ] `SetManifestSplitter`: percentages not summing to 100 raise `ValueError`; split counts match percentages; all input IDs appear in exactly one split; output files named `train_manifest.json`, `val_manifest.json`, `test_manifest.json`; same seed produces same splits
- [ ] `PipelineParams`: new param sections load correctly; missing sections raise
- [ ] `scripts/validate-build` passes (zero warnings)
- [ ] `scripts/validate-tests` passes (all 347 tests)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)