### PR TITLE
Use GIT_ASKPASS with GITHUB_TOKEN in devcontainer instead of host credentials

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,6 +67,8 @@ RUN echo 'export PATH="/opt/ml-env/bin:$PATH"' >> /etc/profile.d/ml-env.sh \
     && chmod +x /etc/profile.d/ml-env.sh
 ENV PATH="/opt/ml-env/bin:$PATH"
 
+COPY --chmod=755 .devcontainer/git-askpass.sh /usr/local/bin/git-askpass
+
 USER vscode
 
 # Create ~/.claude as vscode so Docker initialises the named volume with the

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
         "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
         "DOTNET_NOLOGO": "1",
         "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
-        "GH_TOKEN": "${localEnv:GH_TOKEN}"
+        "GH_TOKEN": "${localEnv:GH_TOKEN}",
+        "GIT_ASKPASS": "/usr/local/bin/git-askpass"
     },
     "customizations": {
         "vscode": {

--- a/.devcontainer/git-askpass.sh
+++ b/.devcontainer/git-askpass.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Git ASKPASS helper: supplies GITHUB_TOKEN for all password prompts.
+# Git calls this script with a prompt string; we return the token for
+# password prompts and a placeholder for username prompts.
+case "$1" in
+    Username*) echo "x-token-auth" ;;
+    Password*) echo "${GITHUB_TOKEN}" ;;
+esac


### PR DESCRIPTION
Adds a git-askpass.sh script baked into the image at /usr/local/bin/git-askpass
that supplies GITHUB_TOKEN for git credential prompts. GIT_ASKPASS is set in
containerEnv so it takes precedence over the VS Code credential helper injected
on each container attach, keeping host git credentials out of the container.