### PR TITLE
Allow automated GitHub PR review posting without prompting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(gh api repos/*/pulls/*/reviews*)",
+      "Bash(gh pr review *)",
+      "mcp__github__pull_request_review_write",
+      "mcp__github__add_comment_to_pending_review",
+      "mcp__github__add_reply_to_pull_request_comment",
+      "mcp__plugin_github_github__pull_request_review_write",
+      "mcp__plugin_github_github__add_comment_to_pending_review",
+      "mcp__plugin_github_github__add_reply_to_pull_request_comment"
+    ]
+  },
   "enabledPlugins": {
     "dotnet@dotnet-agent-skills": false,
     "dotnet-diag@dotnet-agent-skills": true,


### PR DESCRIPTION
## Summary
- The dev-team review/sign-off pipeline was silently stalling: posting a review requires `gh api`/github-MCP calls that weren't pre-approved, so the reviewer agent's Step 7 (post the review) always hit a permission denial.
- Adds narrowly-scoped `allow` rules for review-posting only (`gh api .../reviews`, `gh pr review`, `pull_request_review_write`, `add_comment_to_pending_review`, `add_reply_to_pull_request_comment`) — deliberately excludes `update_pull_request` (draft/reviewer-request), which is separate scope.
- Also flags a naming mismatch: the dev-team plugin's agent definitions reference `mcp__plugin_github_github__*` tools, but this project's `.claude/settings.json` registers the server as plain `github` (`mcp__github__*`). Allowlisted both names since only one will actually resolve; the mismatch itself is a plugin-side issue, out of scope for this fix.

## Test plan
- [ ] After merge, confirm a reviewer agent can post a PR review without a permission prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhMgWJeN4ytrcZdaWZYgqY