### PR TITLE
Wire up REVIEW_ASSIGNEE_EMAIL for hand-off

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "REVIEW_ASSIGNEE_EMAIL": "jodasoft@outlook.com"
+  },
   "enabledPlugins": {
     "dotnet@dotnet-agent-skills": false,
     "dotnet-diag@dotnet-agent-skills": true,


### PR DESCRIPTION
## Summary
- `final-sign-off` and `work-with-pr` reference `$REVIEW_ASSIGNEE_EMAIL` to look up the human reviewer's Jira/GitHub identity at hand-off, but it was never set anywhere — every task's PR hand-off stalled on the reviewer-assignment step (hit on both ADR-338 and ADR-339).
- Sets it to jodasoft@outlook.com (jodavis) per explicit user confirmation.
- Note: PRs in this repo are authored under a separate `jodavis-claude` account (confirmed via a live `gh api` review-post — see PR #246's review), so the GitHub review-request step should NOT hit a self-review conflict as originally assumed.

## Test plan
- [ ] After merge, confirm a task's hand-off successfully assigns the Jira issue and requests jodavis as GitHub reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhMgWJeN4ytrcZdaWZYgqY